### PR TITLE
Introduce App and NavigationActions singletons

### DIFF
--- a/app/src/main/java/com/example/app/AppModule.kt
+++ b/app/src/main/java/com/example/app/AppModule.kt
@@ -1,0 +1,13 @@
+package com.example.app
+
+import com.example.core.common.app.NavigationActions as NavigationActionsApi
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AppModule {
+    @Binds abstract fun bindNavigationActions(actions: NavigationActions): NavigationActionsApi
+}

--- a/app/src/main/java/com/example/app/Nav.kt
+++ b/app/src/main/java/com/example/app/Nav.kt
@@ -1,25 +1,27 @@
 package com.example.app
 
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
-import com.example.feature.catalog.ui.CatalogScreen
-import com.example.feature.detail.ui.DetailScreen
-import com.example.feature.catalog.api.Catalog
-import com.example.feature.detail.api.Detail
 import com.example.core.common.presenter.LocalPresenterResolver
-import javax.inject.Inject
-import dagger.hilt.android.AndroidEntryPoint
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import com.example.core.designsystem.AppTheme
+import com.example.feature.catalog.api.Catalog
+import com.example.feature.catalog.ui.CatalogScreen
+import com.example.feature.detail.api.Detail
+import com.example.feature.detail.ui.DetailScreen
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
   @Inject lateinit var resolver: HiltPresenterResolver
+  @Inject lateinit var navActions: NavigationActions
 
   override fun onCreate(savedInstanceState: android.os.Bundle?) {
     super.onCreate(savedInstanceState)
@@ -28,7 +30,7 @@ class MainActivity : ComponentActivity() {
         androidx.compose.runtime.CompositionLocalProvider(
           LocalPresenterResolver provides resolver
         ) {
-          AppNavHost()
+          AppNavHost(navActions)
         }
       }
     }
@@ -36,10 +38,11 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun AppNavHost() {
+fun AppNavHost(actions: NavigationActions) {
   val nav = rememberNavController()
+  LaunchedEffect(nav) { actions.setNavController(nav) }
   NavHost(nav, startDestination = Catalog) {
-    composable<Catalog> { CatalogScreen(onItemClick = { id -> nav.navigate(Detail(id)) }) }
+    composable<Catalog> { CatalogScreen() }
     composable<Detail> {
       val args = it.toRoute<Detail>()
       DetailScreen(args.id)

--- a/app/src/main/java/com/example/app/NavigationActions.kt
+++ b/app/src/main/java/com/example/app/NavigationActions.kt
@@ -1,0 +1,20 @@
+package com.example.app
+
+import androidx.navigation.NavHostController
+import javax.inject.Inject
+import javax.inject.Singleton
+import com.example.core.common.app.NavigationActions as NavigationActionsApi
+import com.example.feature.detail.api.Detail
+
+@Singleton
+class NavigationActions @Inject constructor() : NavigationActionsApi {
+    private lateinit var navController: NavHostController
+
+    fun setNavController(controller: NavHostController) {
+        navController = controller
+    }
+
+    override fun openDetail(id: String) {
+        navController.navigate(Detail(id))
+    }
+}

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,13 +1,16 @@
 plugins {
   alias(libs.plugins.kotlin)
-  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.kotlin.kapt)
 }
 
 dependencies {
-  implementation(libs.compose.runtime)
   implementation(libs.kotlinx.coroutines.core)
+  implementation("javax.inject:javax.inject:1")
+  implementation("com.google.dagger:dagger:2.52")
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.coroutines.test)
+
+  kapt(libs.hilt.compiler)
 }
 
 kotlin {

--- a/core/common/src/main/kotlin/com/example/core/common/app/App.kt
+++ b/core/common/src/main/kotlin/com/example/core/common/app/App.kt
@@ -1,0 +1,11 @@
+package com.example.core.common.app
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class App @Inject constructor(
+    private val navigation: NavigationActions
+) {
+    fun openDetail(id: String) = navigation.openDetail(id)
+}

--- a/core/common/src/main/kotlin/com/example/core/common/app/NavigationActions.kt
+++ b/core/common/src/main/kotlin/com/example/core/common/app/NavigationActions.kt
@@ -1,0 +1,5 @@
+package com.example.core.common.app
+
+interface NavigationActions {
+    fun openDetail(id: String)
+}

--- a/feature/catalog/api/build.gradle.kts
+++ b/feature/catalog/api/build.gradle.kts
@@ -1,12 +1,10 @@
 plugins {
   alias(libs.plugins.kotlin)
-  alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {
   implementation(project(":core:common"))
-  implementation(libs.compose.runtime)
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
 }

--- a/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
+++ b/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
@@ -12,4 +12,5 @@ data class CatalogState(val items: List<String> = emptyList())
 interface CatalogPresenter {
   val state: StateFlow<CatalogState>
   fun onRefresh()
+  fun onItemClick(id: String)
 }

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
@@ -3,6 +3,7 @@ package com.example.feature.catalog.impl
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.core.common.app.App
 import com.example.feature.catalog.api.CatalogPresenter
 import com.example.feature.catalog.api.CatalogState
 import dagger.Module
@@ -31,7 +32,8 @@ class FakeCatalogRepo @Inject constructor() : CatalogRepo {
 @HiltViewModel
 class CatalogViewModel @Inject constructor(
   private val repo: CatalogRepo,
-  private val saved: SavedStateHandle
+  private val saved: SavedStateHandle,
+  private val app: App
 ) : ViewModel(), CatalogPresenter {
   private val _state = MutableStateFlow(CatalogState())
   override val state: StateFlow<CatalogState> = _state
@@ -40,6 +42,10 @@ class CatalogViewModel @Inject constructor(
     viewModelScope.launch {
       _state.value = _state.value.copy(items = repo.items())
     }
+  }
+
+  override fun onItemClick(id: String) {
+    app.openDetail(id)
   }
 }
 

--- a/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.flow.StateFlow
 @Composable
 fun CatalogScreen(
   presenter: CatalogPresenter? = null,
-  onItemClick: (String) -> Unit = {}
 ) {
   val p = presenter ?: rememberPresenter<CatalogPresenter, Unit>()
   val state by p.state.collectAsStateWithLifecycle()
@@ -34,7 +33,7 @@ fun CatalogScreen(
     Button(onClick = p::onRefresh) { Text("Refresh (${state.items.size})") }
     Spacer(Modifier.height(8.dp))
     state.items.forEach { item ->
-      Text("• " + item, Modifier.clickable { onItemClick(item) })
+      Text("• " + item, Modifier.clickable { p.onItemClick(item) })
     }
   }
 }
@@ -44,6 +43,7 @@ private class FakeCatalogPresenter : CatalogPresenter {
   private val _s = MutableStateFlow(CatalogState(listOf("Alpha","Beta","Gamma")))
   override val state: StateFlow<CatalogState> = _s
   override fun onRefresh() { _s.value = _s.value.copy(items = _s.value.items + "!") }
+  override fun onItemClick(id: String) {}
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Summary
- Add `App` singleton delegating navigation to `NavigationActions`
- Move navigation logic into `NavigationActions` and bind via Hilt
- Update catalog presenter and screen to navigate through `App`
- Remove redundant Compose plugin from non-Compose modules to avoid loading Kotlin Gradle plugin multiple times

## Testing
- `gradle test --warning-mode all` *(fails: Resolve dependencies of detachedConfiguration1 > com.android.application plugin requires Java 17 or environment configuration; build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd45a5b2bc83288e2ce8506712017a