### PR TITLE
chore: add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Build
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: '8.4'
+          arguments: build
+      - name: Unit tests
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: '8.4'
+          arguments: test
+      - name: Publish test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: '**/build/test-results/test/*.xml'


### PR DESCRIPTION
## Summary
- run build and unit tests on pull requests
- comment unit test results on the PR

## Testing
- `gradle test --no-daemon --console=plain` *(fails: timeout while installing Android SDK Build-Tools)*

------
https://chatgpt.com/codex/tasks/task_e_68bd827ca4b88328b27e3766879c870d