### PR TITLE
fix: centralize Kotlin Gradle plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
   alias(libs.plugins.android.app)
-  alias(libs.plugins.kotlin.android)
+  id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
-  alias(libs.plugins.kotlin.compose)
-  alias(libs.plugins.kotlin.kapt)
+  id("org.jetbrains.kotlin.plugin.compose")
+  id("org.jetbrains.kotlin.kapt")
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,12 @@
 plugins {
-  // empty at root
+  alias(libs.plugins.android.app) apply false
+  alias(libs.plugins.android.lib) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin) apply false
+  alias(libs.plugins.kotlin.compose) apply false
+  alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.kotlin.kapt) apply false
+  alias(libs.plugins.hilt) apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  alias(libs.plugins.kotlin)
-  alias(libs.plugins.kotlin.compose)
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 dependencies {

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  alias(libs.plugins.kotlin.android)
-  alias(libs.plugins.kotlin.compose)
+  id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {

--- a/feature/catalog/api/build.gradle.kts
+++ b/feature/catalog/api/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  alias(libs.plugins.kotlin)
-  alias(libs.plugins.kotlin.serialization)
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 dependencies {

--- a/feature/catalog/impl/build.gradle.kts
+++ b/feature/catalog/impl/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
   alias(libs.plugins.android.lib)
-  alias(libs.plugins.kotlin.android)
+  id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
-  alias(libs.plugins.kotlin.kapt)
+  id("org.jetbrains.kotlin.kapt")
 }
 
 android {

--- a/feature/catalog/ui/build.gradle.kts
+++ b/feature/catalog/ui/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  alias(libs.plugins.kotlin.android)
-  alias(libs.plugins.kotlin.compose)
+  id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {

--- a/feature/detail/api/build.gradle.kts
+++ b/feature/detail/api/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  alias(libs.plugins.kotlin)
-  alias(libs.plugins.kotlin.compose)
-  alias(libs.plugins.kotlin.serialization)
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.plugin.compose")
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 dependencies {

--- a/feature/detail/impl/build.gradle.kts
+++ b/feature/detail/impl/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
   alias(libs.plugins.android.lib)
-  alias(libs.plugins.kotlin.android)
+  id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
-  alias(libs.plugins.kotlin.kapt)
+  id("org.jetbrains.kotlin.kapt")
 }
 
 android {

--- a/feature/detail/ui/build.gradle.kts
+++ b/feature/detail/ui/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  alias(libs.plugins.kotlin.android)
-  alias(libs.plugins.kotlin.compose)
+  id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 android.useAndroidX=true
+
+# Increase Gradle memory to avoid Dex merge OOMs during build
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g


### PR DESCRIPTION
## Summary
- define Kotlin plugin versions once in the root build file and mark them `apply false`
- apply Kotlin and related plugins in subprojects without versions to avoid duplicate classloader loads
- raise Gradle JVM memory to prevent Dex merge out-of-memory errors

## Testing
- `gradle build --console=plain`
- `gradle test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68bd967176488328afda07f96e9d0e49