### PR TITLE
ci: publish release apk on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  GRADLE_VERSION: '8.7'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main
+          if ! git branch --contains $GITHUB_SHA | grep -q 'origin/main'; then
+            echo "Tag must reference a commit on main" >&2
+            exit 1
+          fi
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Build Release APK
+        uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: ${{ env.GRADLE_VERSION }}
+          arguments: assembleRelease
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: app/build/outputs/apk/release/app-release-unsigned.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add workflow to build release apk on tag pushes and upload to GitHub Releases

## Testing
- `gradle assembleRelease`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6d2cc508328851ac12a9c6057bd