### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,13 @@ object FooBindings {
 }
 ```
 5. Wire the feature into navigation by updating `NavigationActions` if needed.
+
+## Release
+To publish a release APK through GitHub Actions, create and push an annotated tag:
+
+```bash
+git tag -a v0.1.0 -m "Release 0.1.0"
+git push origin v0.1.0
+```
+
+The CI workflow will build and upload the release APK for that tag.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
     minSdk = 24
     targetSdk = 35
     versionCode = 1
-    versionName = "1.0"
+    versionName = "0.1.0"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
   buildFeatures { compose = true }


### PR DESCRIPTION
## Summary
- bump app versionName to 0.1.0
- document how to tag releases for GitHub Actions

## Testing
- ⚠️ `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcad36ec4832889d214bc17d4525f