### PR TITLE
fix release tag check in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Ensure tag is on main
         run: |
           git fetch origin main
-          if ! git branch --contains $GITHUB_SHA | grep -q 'origin/main'; then
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "Tag must reference a commit on main" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- ensure release workflow verifies tag commit is on `main`

## Testing
- `gradle help` (fails: requires Android SDK to complete)


------
https://chatgpt.com/codex/tasks/task_e_68bdda1783388328a1a7bb16981dd956