### PR TITLE
Migrate Hilt and Room annotation processing to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
   id("org.jetbrains.kotlin.plugin.compose")
-  id("org.jetbrains.kotlin.kapt")
+  id("com.google.devtools.ksp")
 }
 
 android {
@@ -48,7 +48,7 @@ dependencies {
   implementation(libs.navigation.compose)
 
   implementation(libs.hilt.android)
-  kapt(libs.hilt.compiler)
+  ksp(libs.hilt.compiler)
   implementation(libs.hilt.nav.compose)
 
   androidTestImplementation(libs.compose.ui.test.junit4)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   alias(libs.plugins.kotlin) apply false
   alias(libs.plugins.kotlin.compose) apply false
   alias(libs.plugins.kotlin.serialization) apply false
-  alias(libs.plugins.kotlin.kapt) apply false
+  alias(libs.plugins.ksp) apply false
   alias(libs.plugins.hilt) apply false
 }
 

--- a/feature/catalog/impl/build.gradle.kts
+++ b/feature/catalog/impl/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   alias(libs.plugins.android.lib)
   id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
-  id("org.jetbrains.kotlin.kapt")
+  id("com.google.devtools.ksp")
   alias(libs.plugins.kotlin.serialization)
 }
 
@@ -22,7 +22,7 @@ dependencies {
   implementation(project(":core:common"))
 
   implementation(libs.hilt.android)
-  kapt(libs.hilt.compiler)
+  ksp(libs.hilt.compiler)
   implementation(libs.lifecycle.viewmodel.compose)
   implementation(libs.retrofit.core)
   implementation(libs.retrofit.kotlinx)
@@ -31,7 +31,7 @@ dependencies {
   implementation(libs.room.runtime)
   implementation(libs.room.ktx)
   implementation(libs.kotlinx.serialization.json)
-  kapt(libs.room.compiler)
+  ksp(libs.room.compiler)
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.coroutines.test)

--- a/feature/detail/impl/build.gradle.kts
+++ b/feature/detail/impl/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   alias(libs.plugins.android.lib)
   id("org.jetbrains.kotlin.android")
   alias(libs.plugins.hilt)
-  id("org.jetbrains.kotlin.kapt")
+  id("com.google.devtools.ksp")
 }
 
 android {
@@ -22,7 +22,7 @@ dependencies {
   implementation(project(":core:common"))
 
   implementation(libs.hilt.android)
-  kapt(libs.hilt.compiler)
+  ksp(libs.hilt.compiler)
   implementation(libs.lifecycle.viewmodel.compose)
 
   testImplementation(libs.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ junit = "4.13.2"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 room = "2.6.1"
+ksp = "2.0.0-1.0.24"
 
 [plugins]
 android-app = { id = "com.android.application", version.ref = "agp" }
@@ -18,7 +19,7 @@ android-lib = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
## Summary
- Replace Kotlin KAPT with Kotlin Symbol Processing
- Update Hilt and Room dependencies to use `ksp`
- Add KSP plugin and version catalog entries

## Testing
- `gradle :app:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68be55d2917083289880bf81e9431c65