### PR TITLE
Handle network failures in article refresh

### DIFF
--- a/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/ArticleRepositoryTest.kt
+++ b/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/ArticleRepositoryTest.kt
@@ -1,0 +1,84 @@
+package com.example.feature.catalog.impl
+
+import com.example.feature.catalog.impl.data.ArticleEntity
+import com.example.feature.catalog.impl.data.ArticleRepository
+import com.example.feature.catalog.impl.data.ArticleDao
+import com.example.feature.catalog.impl.data.DictionaryEntry
+import com.example.feature.catalog.impl.data.DictionaryService
+import com.example.feature.catalog.impl.data.SummarizerService
+import com.example.feature.catalog.impl.data.TranslationData
+import com.example.feature.catalog.impl.data.TranslationResponse
+import com.example.feature.catalog.impl.data.TranslatorService
+import com.example.feature.catalog.impl.data.WikipediaService
+import com.example.feature.catalog.impl.data.WikipediaSummary
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArticleRepositoryTest {
+
+  @get:Rule
+  val dispatcherRule = MainDispatcherRule()
+
+  private fun summary() = WikipediaSummary(
+    pageid = 1,
+    title = "Title",
+    extract = "Some example extract with random words",
+    contentUrls = WikipediaSummary.ContentUrls(
+      WikipediaSummary.ContentUrls.Desktop("url")
+    )
+  )
+
+  private class FakeArticleDao : ArticleDao {
+    private val data = MutableStateFlow<List<ArticleEntity>>(emptyList())
+    override fun getArticles(): Flow<List<ArticleEntity>> = data
+    override suspend fun getArticle(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
+    override suspend fun insert(article: ArticleEntity) { data.value = data.value + article }
+    val inserted: List<ArticleEntity> get() = data.value
+  }
+
+  @Test
+  fun refreshSkipsOnNetworkError() = runTest {
+    val dao = FakeArticleDao()
+    val repo = ArticleRepository(
+      wiki = object : WikipediaService { override suspend fun randomSummary() = summary() },
+      summarizer = object : SummarizerService { override suspend fun summarize(prompt: String) = "ok" },
+      translator = object : TranslatorService {
+        override suspend fun translate(word: String, langPair: String): TranslationResponse {
+          throw IOException("network")
+        }
+      },
+      dictionary = object : DictionaryService { override suspend fun lookup(word: String) = emptyList<DictionaryEntry>() },
+      dao = dao
+    )
+
+    repo.refresh()
+
+    assertTrue(dao.inserted.isEmpty())
+  }
+
+  @Test
+  fun refreshSkipsOnEmptyTranslation() = runTest {
+    val dao = FakeArticleDao()
+    val repo = ArticleRepository(
+      wiki = object : WikipediaService { override suspend fun randomSummary() = summary() },
+      summarizer = object : SummarizerService { override suspend fun summarize(prompt: String) = "ok" },
+      translator = object : TranslatorService {
+        override suspend fun translate(word: String, langPair: String) = TranslationResponse(TranslationData(""))
+      },
+      dictionary = object : DictionaryService { override suspend fun lookup(word: String) = emptyList<DictionaryEntry>() },
+      dao = dao
+    )
+
+    repo.refresh()
+
+    assertTrue(dao.inserted.isEmpty())
+  }
+}
+


### PR DESCRIPTION
## Summary
- guard article refresh against network failures and empty responses
- test ArticleRepository refresh behavior on network errors and empty translations

## Testing
- `gradle :feature:catalog:impl:test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68be6b26d70c832893693fd0fa4aec4d