### PR TITLE
Add language settings screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
   implementation(project(":feature:detail:api"))
   implementation(project(":feature:detail:ui"))
   implementation(project(":feature:detail:impl"))
+  implementation(project(":feature:settings:api"))
+  implementation(project(":feature:settings:ui"))
+  implementation(project(":feature:settings:impl"))
 
   implementation(libs.activity.compose)
   implementation(libs.compose.ui)

--- a/app/src/main/java/com/example/app/Nav.kt
+++ b/app/src/main/java/com/example/app/Nav.kt
@@ -18,6 +18,8 @@ import com.example.feature.catalog.api.Catalog
 import com.example.feature.catalog.ui.CatalogScreen
 import com.example.feature.detail.api.Detail
 import com.example.feature.detail.ui.DetailScreen
+import com.example.feature.settings.api.Settings
+import com.example.feature.settings.ui.SettingsScreen
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -57,5 +59,6 @@ fun AppNavHost(nav: NavHostController) {
       val args = it.toRoute<Detail>()
       DetailScreen(args.id)
     }
+    composable<Settings> { SettingsScreen() }
   }
 }

--- a/app/src/main/java/com/example/app/NavigationActions.kt
+++ b/app/src/main/java/com/example/app/NavigationActions.kt
@@ -3,11 +3,15 @@ package com.example.app
 import androidx.navigation.NavHostController
 import com.example.core.common.app.NavigationActions as NavigationActionsApi
 import com.example.feature.detail.api.Detail
+import com.example.feature.settings.api.Settings
 
 class NavigationActions(
     private val navController: NavHostController
 ) : NavigationActionsApi {
     override fun openDetail(id: Int) {
         navController.navigate(Detail(id))
+    }
+    override fun openSettings() {
+        navController.navigate(Settings)
     }
 }

--- a/core/common/src/main/kotlin/com/example/core/common/app/NavigationActions.kt
+++ b/core/common/src/main/kotlin/com/example/core/common/app/NavigationActions.kt
@@ -2,4 +2,5 @@ package com.example.core.common.app
 
 interface NavigationActions {
     fun openDetail(id: Int)
+    fun openSettings()
 }

--- a/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
+++ b/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
@@ -15,4 +15,5 @@ interface CatalogPresenter {
   val state: StateFlow<CatalogState>
   fun onRefresh()
   fun onItemClick(id: Int)
+  fun onSettingsClick()
 }

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
@@ -41,6 +41,10 @@ class CatalogViewModel @Inject constructor(
   override fun onItemClick(id: Int) {
     app.navigation.openDetail(id)
   }
+
+  override fun onSettingsClick() {
+    app.navigation.openSettings()
+  }
 }
 
 @Module

--- a/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/CatalogViewModelTest.kt
+++ b/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/CatalogViewModelTest.kt
@@ -27,7 +27,7 @@ class CatalogViewModelTest {
       override suspend fun refresh() { data.value = listOf(ArticleEntity(1,"One","S","C","u","o","t",null), ArticleEntity(2,"Two","S","C","u","o","t",null)) }
       override suspend fun article(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
     }
-    val nav = object : NavigationActions { override fun openDetail(id: Int) {} }
+    val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }
     val vm = CatalogViewModel(repo, App(nav))
 
     vm.onRefresh()

--- a/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
@@ -31,6 +31,8 @@ fun CatalogScreen(
   Column(Modifier.padding(16.dp)) {
     Text("Catalog", style = MaterialTheme.typography.titleLarge)
     Spacer(Modifier.height(8.dp))
+    Button(onClick = p::onSettingsClick) { Text("Settings") }
+    Spacer(Modifier.height(8.dp))
     Button(onClick = p::onRefresh) { Text("Refresh (${state.items.size})") }
     Spacer(Modifier.height(8.dp))
     state.items.forEach { item ->
@@ -49,6 +51,7 @@ private class FakeCatalogPresenter : CatalogPresenter {
   override val state: StateFlow<CatalogState> = _s
   override fun onRefresh() { _s.value = _s.value.copy(items = _s.value.items + CatalogItem(_s.value.items.size+1,"New","Sum")) }
   override fun onItemClick(id: Int) {}
+  override fun onSettingsClick() {}
 }
 
 @Preview(showBackground = true)

--- a/feature/settings/api/build.gradle.kts
+++ b/feature/settings/api/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+dependencies {
+  implementation(project(":core:common"))
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+  }
+}
+
+java {
+  toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+}
+
+tasks.withType<JavaCompile>().configureEach {
+  options.release.set(21)
+}

--- a/feature/settings/api/src/main/kotlin/com/example/feature/settings/api/SettingsContracts.kt
+++ b/feature/settings/api/src/main/kotlin/com/example/feature/settings/api/SettingsContracts.kt
@@ -1,0 +1,20 @@
+package com.example.feature.settings.api
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object Settings
+
+val supportedLanguages = listOf("English", "Spanish", "French", "German")
+
+data class SettingsState(
+    val nativeLanguage: String = supportedLanguages.first(),
+    val learningLanguage: String = supportedLanguages[1]
+)
+
+interface SettingsPresenter {
+    val state: StateFlow<SettingsState>
+    fun onNativeSelected(language: String)
+    fun onLearningSelected(language: String)
+}

--- a/feature/settings/impl/build.gradle.kts
+++ b/feature/settings/impl/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+  alias(libs.plugins.android.lib)
+  id("org.jetbrains.kotlin.android")
+  alias(libs.plugins.hilt)
+  id("com.google.devtools.ksp")
+}
+
+android {
+  namespace = "com.example.feature.settings.impl"
+  compileSdk = 35
+  defaultConfig { minSdk = 24 }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+  }
+  kotlinOptions { jvmTarget = "21" }
+}
+
+dependencies {
+  implementation(project(":feature:settings:api"))
+  implementation(project(":core:common"))
+
+  implementation(libs.hilt.android)
+  ksp(libs.hilt.compiler)
+  implementation(libs.lifecycle.viewmodel.compose)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/feature/settings/impl/src/main/AndroidManifest.xml
+++ b/feature/settings/impl/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.feature.settings.impl"/>

--- a/feature/settings/impl/src/main/java/com/example/feature/settings/impl/SettingsImpl.kt
+++ b/feature/settings/impl/src/main/java/com/example/feature/settings/impl/SettingsImpl.kt
@@ -1,0 +1,40 @@
+package com.example.feature.settings.impl
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.feature.settings.api.SettingsPresenter
+import com.example.feature.settings.api.SettingsState
+import com.example.feature.settings.impl.data.SettingsRepository
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.ClassKey
+import dagger.multibindings.IntoMap
+import javax.inject.Inject
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val repo: SettingsRepository
+) : ViewModel(), SettingsPresenter {
+    override val state: StateFlow<SettingsState> = repo.state
+
+    override fun onNativeSelected(language: String) {
+        viewModelScope.launch { repo.updateNative(language) }
+    }
+
+    override fun onLearningSelected(language: String) {
+        viewModelScope.launch { repo.updateLearning(language) }
+    }
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object SettingsBindings {
+    @dagger.Provides
+    @IntoMap
+    @ClassKey(SettingsPresenter::class)
+    fun bindSettingsPresenter(): Class<out ViewModel> = SettingsViewModel::class.java
+}

--- a/feature/settings/impl/src/main/java/com/example/feature/settings/impl/data/SettingsRepository.kt
+++ b/feature/settings/impl/src/main/java/com/example/feature/settings/impl/data/SettingsRepository.kt
@@ -1,0 +1,21 @@
+package com.example.feature.settings.impl.data
+
+import com.example.feature.settings.api.SettingsState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingsRepository @Inject constructor() {
+    private val _state = MutableStateFlow(SettingsState())
+    val state: StateFlow<SettingsState> = _state
+
+    suspend fun updateNative(language: String) {
+        _state.value = _state.value.copy(nativeLanguage = language)
+    }
+
+    suspend fun updateLearning(language: String) {
+        _state.value = _state.value.copy(learningLanguage = language)
+    }
+}

--- a/feature/settings/ui/build.gradle.kts
+++ b/feature/settings/ui/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+  alias(libs.plugins.android.lib)
+  id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")
+}
+
+android {
+  namespace = "com.example.feature.settings.ui"
+  compileSdk = 35
+  defaultConfig { minSdk = 24 }
+  buildFeatures { compose = true }
+  composeOptions { kotlinCompilerExtensionVersion = libs.versions.compose.get() }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+  }
+  kotlinOptions { jvmTarget = "21" }
+}
+
+dependencies {
+  implementation(project(":feature:settings:api"))
+  implementation(project(":core:designsystem"))
+  implementation(project(":core:common"))
+
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.preview)
+  implementation(libs.lifecycle.runtime.compose)
+  debugImplementation(libs.compose.tooling)
+}

--- a/feature/settings/ui/src/main/AndroidManifest.xml
+++ b/feature/settings/ui/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.feature.settings.ui"/>

--- a/feature/settings/ui/src/main/java/com/example/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/ui/src/main/java/com/example/feature/settings/ui/SettingsScreen.kt
@@ -1,0 +1,81 @@
+package com.example.feature.settings.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.core.common.presenter.rememberPresenter
+import com.example.core.designsystem.AppTheme
+import com.example.feature.settings.api.SettingsPresenter
+import com.example.feature.settings.api.SettingsState
+import com.example.feature.settings.api.supportedLanguages
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+fun SettingsScreen(presenter: SettingsPresenter? = null) {
+    val p = presenter ?: rememberPresenter<SettingsPresenter, Unit>()
+    val state by p.state.collectAsStateWithLifecycle()
+    Column(Modifier.padding(16.dp)) {
+        Text("Settings", style = MaterialTheme.typography.titleLarge)
+        Spacer(Modifier.height(8.dp))
+        Text("Native language")
+        LanguageDropdown(state.nativeLanguage, p::onNativeSelected)
+        Spacer(Modifier.height(16.dp))
+        Text("Learning language")
+        LanguageDropdown(state.learningLanguage, p::onLearningSelected)
+    }
+}
+
+@Composable
+private fun LanguageDropdown(selected: String, onSelect: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        OutlinedButton(onClick = { expanded = true }) {
+            Text(selected)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            supportedLanguages.forEach { lang ->
+                DropdownMenuItem(
+                    text = { Text(lang) },
+                    onClick = {
+                        expanded = false
+                        onSelect(lang)
+                    }
+                )
+            }
+        }
+    }
+}
+
+// ---- Fake for preview ----
+private class FakeSettingsPresenter : SettingsPresenter {
+    private val _state = MutableStateFlow(SettingsState())
+    override val state: StateFlow<SettingsState> = _state
+    override fun onNativeSelected(language: String) {
+        _state.value = _state.value.copy(nativeLanguage = language)
+    }
+    override fun onLearningSelected(language: String) {
+        _state.value = _state.value.copy(learningLanguage = language)
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview(showBackground = true)
+@Composable
+private fun PreviewSettings() {
+    AppTheme { SettingsScreen(presenter = FakeSettingsPresenter()) }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,5 +24,8 @@ include(
   ":feature:catalog:impl",
   ":feature:detail:api",
   ":feature:detail:ui",
-  ":feature:detail:impl"
+  ":feature:detail:impl",
+  ":feature:settings:api",
+  ":feature:settings:ui",
+  ":feature:settings:impl"
 )


### PR DESCRIPTION
## Summary
- introduce settings feature with API, repository, ViewModel and Jetpack Compose screen for choosing native and learning languages
- extend navigation to include a settings route and expose `openSettings` action
- add entry point from catalog screen to open the settings

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68be6b7d08008328b898a6871adc3060