### PR TITLE
refactor: unify plugin declarations via version catalog aliases

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
   alias(libs.plugins.android.app)
-  id("org.jetbrains.kotlin.android")
+  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.hilt)
-  id("org.jetbrains.kotlin.plugin.compose")
-  id("com.google.devtools.ksp")
+  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.ksp)
 }
 
 android {

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin)
+  alias(libs.plugins.kotlin.compose)
 }
 
 dependencies {

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/catalog/api/build.gradle.kts
+++ b/feature/catalog/api/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.kotlin.plugin.serialization")
+  alias(libs.plugins.kotlin)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {

--- a/feature/catalog/impl/build.gradle.kts
+++ b/feature/catalog/impl/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
+  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.hilt)
-  id("com.google.devtools.ksp")
+  alias(libs.plugins.ksp)
   alias(libs.plugins.kotlin.serialization)
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/catalog/ui/build.gradle.kts
+++ b/feature/catalog/ui/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/detail/api/build.gradle.kts
+++ b/feature/detail/api/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.kotlin.plugin.compose")
-  id("org.jetbrains.kotlin.plugin.serialization")
+  alias(libs.plugins.kotlin)
+  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {

--- a/feature/detail/impl/build.gradle.kts
+++ b/feature/detail/impl/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
+  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.hilt)
-  id("com.google.devtools.ksp")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/detail/ui/build.gradle.kts
+++ b/feature/detail/ui/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/settings/api/build.gradle.kts
+++ b/feature/settings/api/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("org.jetbrains.kotlin.jvm")
-  id("org.jetbrains.kotlin.plugin.serialization")
+  alias(libs.plugins.kotlin)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {

--- a/feature/settings/impl/build.gradle.kts
+++ b/feature/settings/impl/build.gradle.kts
@@ -1,9 +1,9 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
+  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.hilt)
-  id("com.google.devtools.ksp")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {

--- a/feature/settings/ui/build.gradle.kts
+++ b/feature/settings/ui/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.android.lib)
-  id("org.jetbrains.kotlin.android")
-  id("org.jetbrains.kotlin.plugin.compose")
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {


### PR DESCRIPTION
## Summary
- replace hard-coded Kotlin and KSP plugin IDs with version catalog aliases in all modules

## Testing
- `./gradlew -version`
- `./gradlew help --console=plain` *(fails: command hung, likely due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc2b2c648328a9a1957528edfb64