### PR TITLE
Lazy catalog items with dedicated viewmodels

### DIFF
--- a/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
+++ b/feature/catalog/api/src/main/kotlin/com/example/feature/catalog/api/CatalogContracts.kt
@@ -10,11 +10,19 @@ data object Catalog
 data class CatalogItem(val id: Int, val title: String, val summary: String)
 
 // Presenter & state
-data class CatalogState(val items: List<CatalogItem> = emptyList())
+data class CatalogState(val items: List<Int> = emptyList())
 
-interface CatalogPresenter : ParamInit<Unit> {
+interface CatalogItemBridge {
+  fun onItemClick(id: Int)
+}
+
+interface CatalogPresenter : ParamInit<Unit>, CatalogItemBridge {
   val state: StateFlow<CatalogState>
   fun onRefresh()
-  fun onItemClick(id: Int)
   fun onSettingsClick()
+}
+
+interface CatalogItemPresenter : ParamInit<Int> {
+  val state: StateFlow<CatalogItem>
+  fun onClick()
 }

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogBridge.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogBridge.kt
@@ -1,0 +1,16 @@
+package com.example.feature.catalog.impl
+
+import com.example.feature.catalog.api.CatalogItemBridge
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CatalogBridge @Inject constructor() : CatalogItemBridge {
+  private var delegate: CatalogItemBridge? = null
+
+  fun setDelegate(d: CatalogItemBridge) { delegate = d }
+
+  override fun onItemClick(id: Int) {
+    delegate?.onItemClick(id)
+  }
+}

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogImpl.kt
@@ -3,7 +3,6 @@ package com.example.feature.catalog.impl
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.core.common.app.App
-import com.example.feature.catalog.api.CatalogItem
 import com.example.feature.catalog.api.CatalogPresenter
 import com.example.feature.catalog.api.CatalogState
 import com.example.feature.catalog.impl.data.ArticleRepo
@@ -16,15 +15,17 @@ import javax.inject.Inject
 @HiltViewModel
 class CatalogViewModel @Inject constructor(
   private val repo: ArticleRepo,
-  private val app: App
+  private val app: App,
+  private val bridge: CatalogBridge,
 ) : ViewModel(), CatalogPresenter {
   private val _state = MutableStateFlow(CatalogState())
   override val state: StateFlow<CatalogState> = _state
 
   init {
+    bridge.setDelegate(this)
     viewModelScope.launch {
       repo.articles.collect { list ->
-        _state.value = CatalogState(list.map { CatalogItem(it.id, it.title, it.summary) })
+        _state.value = CatalogState(list.map { it.id })
       }
     }
   }
@@ -33,12 +34,12 @@ class CatalogViewModel @Inject constructor(
     viewModelScope.launch { repo.refresh() }
   }
 
-  override fun onItemClick(id: Int) {
-    app.navigation.openDetail(id)
-  }
-
   override fun onSettingsClick() {
     app.navigation.openSettings()
+  }
+
+  override fun onItemClick(id: Int) {
+    app.navigation.openDetail(id)
   }
 
   override fun initOnce(params: Unit) {

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogItemViewModel.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogItemViewModel.kt
@@ -1,0 +1,33 @@
+package com.example.feature.catalog.impl
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.feature.catalog.api.CatalogItem
+import com.example.feature.catalog.api.CatalogItemPresenter
+import com.example.feature.catalog.impl.data.ArticleRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class CatalogItemViewModel @Inject constructor(
+  private val repo: ArticleRepo,
+  private val bridge: CatalogBridge,
+) : ViewModel(), CatalogItemPresenter {
+  private val _state = MutableStateFlow(CatalogItem(0, "", ""))
+  override val state: StateFlow<CatalogItem> = _state
+
+  override fun initOnce(params: Int) {
+    viewModelScope.launch {
+      repo.article(params)?.let {
+        _state.value = CatalogItem(it.id, it.title, it.summary)
+      }
+    }
+  }
+
+  override fun onClick() {
+    bridge.onItemClick(_state.value.id)
+  }
+}

--- a/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogPresenterProvider.kt
+++ b/feature/catalog/impl/src/main/java/com/example/feature/catalog/impl/CatalogPresenterProvider.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.core.common.presenter.PresenterProvider
 import com.example.feature.catalog.api.CatalogPresenter
+import com.example.feature.catalog.api.CatalogItemPresenter
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,6 +23,18 @@ object CatalogPresenterBindings {
             @Composable
             override fun provide(key: String?): CatalogPresenter {
                 return hiltViewModel<CatalogViewModel>(key = key)
+            }
+        }
+    }
+
+    @Provides
+    @IntoMap
+    @ClassKey(CatalogItemPresenter::class)
+    fun provideCatalogItemPresenterProvider(): PresenterProvider<*> {
+        return object : PresenterProvider<CatalogItemPresenter> {
+            @Composable
+            override fun provide(key: String?): CatalogItemPresenter {
+                return hiltViewModel<CatalogItemViewModel>(key = key)
             }
         }
     }

--- a/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/CatalogViewModelTest.kt
+++ b/feature/catalog/impl/src/test/java/com/example/feature/catalog/impl/CatalogViewModelTest.kt
@@ -5,6 +5,7 @@ import com.example.core.common.app.App
 import com.example.core.common.app.NavigationActions
 import com.example.feature.catalog.impl.data.ArticleEntity
 import com.example.feature.catalog.impl.data.ArticleRepo
+import com.example.feature.catalog.impl.CatalogBridge
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -28,11 +29,12 @@ class CatalogViewModelTest {
       override suspend fun article(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
     }
     val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }
-    val vm = CatalogViewModel(repo, App(nav))
+    val bridge = CatalogBridge()
+    val vm = CatalogViewModel(repo, App(nav), bridge)
 
     vm.onRefresh()
     advanceUntilIdle()
 
-    assertEquals(listOf("One", "Two"), vm.state.value.items.map { it.title })
+    assertEquals(listOf(1, 2), vm.state.value.items)
   }
 }

--- a/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogItemCard.kt
+++ b/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogItemCard.kt
@@ -1,0 +1,54 @@
+package com.example.feature.catalog.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.core.common.presenter.rememberPresenter
+import com.example.core.designsystem.AppTheme
+import com.example.core.designsystem.LiquidGlassBox
+import com.example.feature.catalog.api.CatalogItem
+import com.example.feature.catalog.api.CatalogItemPresenter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+fun CatalogItemCard(
+  id: Int,
+  presenter: CatalogItemPresenter? = null,
+) {
+  val p = presenter ?: rememberPresenter<CatalogItemPresenter, Int>(key = "item$id", params = id)
+  val state by p.state.collectAsStateWithLifecycle()
+  LiquidGlassBox(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable { p.onClick() }
+  ) {
+    Column(Modifier.padding(12.dp)) {
+      Text(state.title)
+      Text(state.summary, style = MaterialTheme.typography.bodySmall)
+    }
+  }
+}
+
+// ---- Fake for preview ----
+private class FakeCatalogItemPresenter : CatalogItemPresenter {
+  private val _s = MutableStateFlow(CatalogItem(1, "Alpha", "Summary"))
+  override val state: StateFlow<CatalogItem> = _s
+  override fun onClick() {}
+  override fun initOnce(params: Int) {}
+}
+
+@Preview
+@Composable
+private fun PreviewCatalogItemCard() {
+  AppTheme { CatalogItemCard(id = 1, presenter = FakeCatalogItemPresenter()) }
+}

--- a/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/example/feature/catalog/ui/CatalogScreen.kt
@@ -1,11 +1,11 @@
 package com.example.feature.catalog.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -17,10 +17,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.core.common.presenter.rememberPresenter
 import com.example.core.designsystem.AppTheme
-import com.example.core.designsystem.LiquidGlassBox
 import com.example.feature.catalog.api.CatalogPresenter
 import com.example.feature.catalog.api.CatalogState
-import com.example.feature.catalog.api.CatalogItem
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -37,27 +35,20 @@ fun CatalogScreen(
     Spacer(Modifier.height(8.dp))
     Button(onClick = p::onRefresh) { Text("Refresh (${state.items.size})") }
     Spacer(Modifier.height(8.dp))
-    state.items.forEach { item ->
-      LiquidGlassBox(
-        modifier = Modifier
-          .fillMaxWidth()
-          .clickable { p.onItemClick(item.id) }
-      ) {
-        Column(Modifier.padding(12.dp)) {
-          Text(item.title)
-          Text(item.summary, style = MaterialTheme.typography.bodySmall)
-        }
+    LazyColumn {
+      items(state.items) { id ->
+        CatalogItemCard(id = id)
+        Spacer(Modifier.height(8.dp))
       }
-      Spacer(Modifier.height(8.dp))
     }
   }
 }
 
 // ---- Fake for preview (no Hilt in UI module) ----
 private class FakeCatalogPresenter : CatalogPresenter {
-  private val _s = MutableStateFlow(CatalogState(listOf(CatalogItem(1, "Alpha", "Summary"))))
+  private val _s = MutableStateFlow(CatalogState(listOf(1)))
   override val state: StateFlow<CatalogState> = _s
-  override fun onRefresh() { _s.value = _s.value.copy(items = _s.value.items + CatalogItem(_s.value.items.size+1,"New","Sum")) }
+  override fun onRefresh() { _s.value = _s.value.copy(items = _s.value.items + (_s.value.items.size+1)) }
   override fun onItemClick(id: Int) {}
   override fun onSettingsClick() {}
   override fun initOnce(params: Unit) {}


### PR DESCRIPTION
## Summary
- split catalog item rendering into `CatalogItemCard` backed by its own presenter
- provide `CatalogBridge` and `CatalogItemViewModel` to lazily load and handle item clicks
- update catalog contracts and screen to work with item ids and lazy components

## Testing
- `./gradlew test --no-daemon` *(fails: resolve dependencies of classpath netty-buffer)*

------
https://chatgpt.com/codex/tasks/task_e_68c11eb5d3708328ab83270533da079f