### PR TITLE
Update Gradle wrapper to 8.13

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- set Gradle wrapper to 8.13 to match Android Gradle Plugin requirements

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: Task :core:designsystem:compileDebugKotlin FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_68c13e6dd3a08328b78166bd24afc63c