### PR TITLE
chore: update gradle wrapper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update Gradle wrapper to 9.0.0
- verify Gradle distribution with SHA-256 checksum
- restore original gradle-wrapper.jar to avoid committing binary updates

## Testing
- `./gradlew --version --no-daemon --console=plain`
- `./gradlew help --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c30e553b408328a0ac161e7db1fa21