### PR TITLE
chore: use Gradle 8.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  GRADLE_VERSION: '8.7'
+  GRADLE_VERSION: '8.13'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  GRADLE_VERSION: '8.7'
+  GRADLE_VERSION: '8.13'
 
 permissions:
   contents: write

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
-distributionSha256Sum=8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b
+distributionSha256Sum=20f1b1176237254a6fc204d8434196fa11a4cfb387567519c61556e8710aed78
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- use Gradle wrapper 8.13 and its SHA256 checksum
- run CI and release workflows against Gradle 8.13
- drop gradle-wrapper.jar update from the PR

## Testing
- `./gradlew help --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c5010868dc8328b11a88f79e2ad941