### PR TITLE
Broaden settings language support

### DIFF
--- a/feature/catalog/impl/build.gradle.kts
+++ b/feature/catalog/impl/build.gradle.kts
@@ -22,6 +22,8 @@ android {
 dependencies {
   implementation(project(":feature:catalog:api"))
   implementation(project(":core:common"))
+  implementation(project(":feature:settings:api"))
+  implementation(project(":feature:settings:impl"))
 
   implementation(libs.hilt.android)
   ksp(libs.hilt.compiler)

--- a/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/ArticleRepositoryTest.kt
+++ b/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/ArticleRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.archstarter.feature.catalog.impl.data.TranslationResponse
 import com.archstarter.feature.catalog.impl.data.TranslatorService
 import com.archstarter.feature.catalog.impl.data.WikipediaService
 import com.archstarter.feature.catalog.impl.data.WikipediaSummary
+import com.archstarter.feature.settings.impl.data.SettingsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,6 +56,7 @@ class ArticleRepositoryTest {
         }
       },
       dictionary = object : DictionaryService { override suspend fun lookup(word: String) = emptyList<DictionaryEntry>() },
+      settings = SettingsRepository(),
       dao = dao
     )
 
@@ -73,6 +75,7 @@ class ArticleRepositoryTest {
         override suspend fun translate(word: String, langPair: String) = TranslationResponse(TranslationData(""))
       },
       dictionary = object : DictionaryService { override suspend fun lookup(word: String) = emptyList<DictionaryEntry>() },
+      settings = SettingsRepository(),
       dao = dao
     )
 

--- a/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
+++ b/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
@@ -3,15 +3,26 @@ package com.archstarter.feature.settings.api
 import com.archstarter.core.common.presenter.ParamInit
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
+import java.util.LinkedHashMap
+import java.util.Locale
 
 @Serializable
 data object Settings
 
-val supportedLanguages = listOf("English", "Spanish", "French", "German")
+val languageCodes: Map<String, String> =
+    Locale.getISOLanguages()
+        .map { code ->
+            val name = Locale(code).getDisplayLanguage(Locale.ENGLISH)
+            name.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ENGLISH) else it.toString() } to code
+        }
+        .sortedBy { it.first }
+        .toMap(LinkedHashMap())
+
+val supportedLanguages = languageCodes.keys.toList()
 
 data class SettingsState(
-    val nativeLanguage: String = supportedLanguages.first(),
-    val learningLanguage: String = supportedLanguages[1]
+    val nativeLanguage: String = "English",
+    val learningLanguage: String = "Spanish"
 )
 
 interface SettingsPresenter: ParamInit<Unit> {


### PR DESCRIPTION
## Summary
- include mapping for many languages with ISO codes
- use settings to pick translation language pair
- wire catalog feature to settings module
- generate language list from all ISO 639-1 codes and default to English/Spanish

## Testing
- `./gradlew :feature:settings:api:compileKotlin --no-daemon --console=plain --info` *(fails: dependency download ran indefinitely and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c558457ec48328ad6a73f9eb103685