### PR TITLE
Center liquid glass overlay in catalog

### DIFF
--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogItemCard.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogItemCard.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.archstarter.core.common.presenter.rememberPresenter
 import com.archstarter.core.designsystem.AppTheme
-import com.archstarter.core.designsystem.LiquidGlassBox
 import com.archstarter.feature.catalog.api.CatalogItem
 import com.archstarter.feature.catalog.api.CatalogItemPresenter
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,15 +26,14 @@ fun CatalogItemCard(
 ) {
   val p = presenter ?: rememberPresenter<CatalogItemPresenter, Int>(key = "item$id", params = id)
   val state by p.state.collectAsStateWithLifecycle()
-  LiquidGlassBox(
+  Column(
     modifier = Modifier
       .fillMaxWidth()
       .clickable { p.onClick() }
+      .padding(12.dp)
   ) {
-    Column(Modifier.padding(12.dp)) {
-      Text(state.title)
-      Text(state.summary, style = MaterialTheme.typography.bodySmall)
-    }
+    Text(state.title)
+    Text(state.summary, style = MaterialTheme.typography.bodySmall)
   }
 }
 

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -1,24 +1,27 @@
 package com.archstarter.feature.catalog.ui
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.archstarter.core.common.presenter.rememberPresenter
 import com.archstarter.core.designsystem.AppTheme
+import com.archstarter.core.designsystem.LiquidGlassBox
 import com.archstarter.feature.catalog.api.CatalogPresenter
 import com.archstarter.feature.catalog.api.CatalogState
+import kotlin.math.abs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -28,17 +31,45 @@ fun CatalogScreen(
 ) {
   val p = presenter ?: rememberPresenter<CatalogPresenter, Unit>()
   val state by p.state.collectAsStateWithLifecycle()
-  Column(Modifier.padding(16.dp)) {
+  val listState = rememberLazyListState()
+  val density = LocalDensity.current
+  val centeredHeight by remember {
+    derivedStateOf {
+      val info = listState.layoutInfo
+      val viewportCenter = (info.viewportStartOffset + info.viewportEndOffset) / 2
+      val item = info.visibleItemsInfo.minByOrNull {
+        abs((it.offset + it.size / 2) - viewportCenter)
+      }
+      item?.size?.let { with(density) { it.toDp() } } ?: 0.dp
+    }
+  }
+  val glassHeight by animateDpAsState(
+    targetValue = centeredHeight,
+    animationSpec = tween(durationMillis = 300, delayMillis = 100),
+    label = "glassHeight"
+  )
+
+  Column(Modifier.fillMaxSize().padding(16.dp)) {
     Text("Catalog", style = MaterialTheme.typography.titleLarge)
     Spacer(Modifier.height(8.dp))
     Button(onClick = p::onSettingsClick) { Text("Settings") }
     Spacer(Modifier.height(8.dp))
     Button(onClick = p::onRefresh) { Text("Refresh (${state.items.size})") }
     Spacer(Modifier.height(8.dp))
-    LazyColumn {
-      items(state.items) { id ->
-        CatalogItemCard(id = id)
-        Spacer(Modifier.height(8.dp))
+    Box(Modifier.weight(1f)) {
+      LazyColumn(state = listState) {
+        items(state.items) { id ->
+          CatalogItemCard(id = id)
+          Spacer(Modifier.height(8.dp))
+        }
+      }
+      if (glassHeight > 0.dp) {
+        LiquidGlassBox(
+          modifier = Modifier
+            .align(Alignment.Center)
+            .fillMaxWidth()
+            .height(glassHeight)
+        )
       }
     }
   }


### PR DESCRIPTION
## Summary
- Move liquid glass effect from individual items to a single overlay tracking the centered list item
- Simplify `CatalogItemCard` to remove per-item LiquidGlass wrapper

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c6bcbaf53883288fbb2143c52f3fc1