### PR TITLE
Fix translation language order and add test

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
@@ -50,7 +50,7 @@ class ArticleRepository @Inject constructor(
     val original = words.randomOrNull() ?: return
 
     val state = settings.state.value
-    val langPair = "${languageCodes[state.learningLanguage]}|${languageCodes[state.nativeLanguage]}"
+    val langPair = "${languageCodes[state.nativeLanguage]}|${languageCodes[state.learningLanguage]}"
     val translation = runCatching {
       translator.translate(original, langPair).responseData.translatedText
     }.getOrElse { return }.takeIf { it.isNotBlank() } ?: return


### PR DESCRIPTION
## Summary
- fix translation to use native-to-learning language order
- add unit test ensuring translator receives correct language pair

## Testing
- `./gradlew :feature:catalog:impl:test`


------
https://chatgpt.com/codex/tasks/task_e_68c5bfc6375c8328a4df57595536ab8c