### PR TITLE
feat(detail): add liquid glass translation overlay

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
@@ -25,6 +25,7 @@ interface ArticleRepo {
   val articles: Flow<List<ArticleEntity>>
   suspend fun refresh()
   suspend fun article(id: Int): ArticleEntity?
+  suspend fun translate(word: String): String?
 }
 
 @Singleton
@@ -74,6 +75,14 @@ class ArticleRepository @Inject constructor(
   }
 
   override suspend fun article(id: Int): ArticleEntity? = dao.getArticle(id)
+
+  override suspend fun translate(word: String): String? {
+    val state = settings.state.value
+    val langPair = "${languageCodes[state.learningLanguage]}|${languageCodes[state.nativeLanguage]}"
+    return runCatching { translator.translate(word, langPair).responseData.translatedText }
+      .getOrNull()
+      ?.takeIf { it.isNotBlank() }
+  }
 
   private suspend fun <T> retry(times: Int = 3, block: suspend () -> T): T {
     repeat(times - 1) { attempt ->

--- a/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/CatalogViewModelTest.kt
+++ b/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/CatalogViewModelTest.kt
@@ -28,6 +28,7 @@ class CatalogViewModelTest {
       override val articles: StateFlow<List<ArticleEntity>> = data
       override suspend fun refresh() { data.value = listOf(ArticleEntity(1,"One","S","C","u","o","t",null), ArticleEntity(2,"Two","S","C","u","o","t",null)) }
       override suspend fun article(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
+      override suspend fun translate(word: String): String? = word
     }
     val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }
     val bridge = CatalogBridge()

--- a/feature/detail/api/src/main/kotlin/com/archstarter/feature/detail/api/DetailContracts.kt
+++ b/feature/detail/api/src/main/kotlin/com/archstarter/feature/detail/api/DetailContracts.kt
@@ -14,8 +14,11 @@ data class DetailState(
   val originalWord: String = "",
   val translatedWord: String = "",
   val ipa: String? = null,
+  val highlightedWord: String? = null,
+  val highlightedTranslation: String? = null,
 )
 
 interface DetailPresenter : ParamInit<Int> {
   val state: StateFlow<DetailState>
+  fun translate(word: String)
 }

--- a/feature/detail/impl/src/main/java/com/archstarter/feature/detail/impl/DetailImpl.kt
+++ b/feature/detail/impl/src/main/java/com/archstarter/feature/detail/impl/DetailImpl.kt
@@ -63,6 +63,16 @@ class DetailViewModel @AssistedInject constructor(
         }
     }
 
+    override fun translate(word: String) {
+        viewModelScope.launch {
+            val translation = repo.translate(word) ?: return@launch
+            _state.value = _state.value.copy(
+                highlightedWord = word,
+                highlightedTranslation = translation
+            )
+        }
+    }
+
     @AssistedFactory
     interface Factory : AssistedVmFactory<DetailViewModel>
 }

--- a/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
+++ b/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
@@ -1,14 +1,29 @@
 package com.archstarter.feature.detail.ui
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.pointer.consumeAllChanges
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.archstarter.core.common.presenter.rememberPresenter
 import com.archstarter.core.designsystem.AppTheme
@@ -21,9 +36,67 @@ import kotlinx.coroutines.flow.StateFlow
 fun DetailScreen(id: Int, presenter: DetailPresenter? = null) {
   val p = presenter ?: rememberPresenter<DetailPresenter, Int>(params = id)
   val state by p.state.collectAsStateWithLifecycle()
+  val density = LocalDensity.current
+  var layout by remember { mutableStateOf<TextLayoutResult?>(null) }
+  var currentWord by remember { mutableStateOf("") }
+  var targetRect by remember { mutableStateOf<Rect?>(null) }
+  val animRect = remember { Animatable(Rect.Zero, Rect.VectorConverter) }
+
+  LaunchedEffect(targetRect) {
+    targetRect?.let { animRect.animateTo(it) }
+  }
+
   Column(Modifier.padding(16.dp)) {
     Text(state.title, style = MaterialTheme.typography.titleLarge)
-    Text(state.content)
+    Box {
+      Text(
+        text = state.highlightedWord?.let { w ->
+          state.highlightedTranslation?.let { t ->
+            state.content.replaceFirst(w, t)
+          }
+        } ?: state.content,
+        onTextLayout = { layout = it },
+        modifier = Modifier.pointerInput(state.content) {
+          awaitPointerEventScope {
+            while (true) {
+              val event = awaitPointerEvent()
+              val pos = event.changes.first().position
+              val layoutResult = layout ?: continue
+              val text = state.content
+              val index = layoutResult.getOffsetForPosition(pos).coerceIn(0, text.length)
+              if (index < text.length) {
+                val start = text.take(index).lastIndexOfAny(charArrayOf(' ', '\n')) + 1
+                val end = text.indexOfAny(charArrayOf(' ', '\n'), start).let { if (it == -1) text.length else it }
+                val word = text.substring(start, end)
+                if (word.isNotBlank() && word != currentWord) {
+                  currentWord = word
+                  val startBox = layoutResult.getBoundingBox(start)
+                  val endBox = layoutResult.getBoundingBox(end - 1)
+                  targetRect = Rect(startBox.left, startBox.top, endBox.right, startBox.bottom)
+                  p.translate(word)
+                }
+              }
+              event.changes.forEach { it.consumeAllChanges() }
+            }
+          }
+        }
+      )
+      if (state.highlightedWord != null && state.highlightedTranslation != null) {
+        val rect = animRect.value
+        Box(
+          Modifier
+            .offset { IntOffset(rect.left.toInt(), rect.top.toInt()) }
+            .size(
+              with(density) { rect.width.toDp() },
+              with(density) { rect.height.toDp() }
+            )
+            .background(
+              MaterialTheme.colorScheme.secondary.copy(alpha = 0.3f),
+              shape = MaterialTheme.shapes.small
+            )
+        )
+      }
+    }
     if (state.ipa != null) {
       Text("IPA: ${state.ipa}", style = MaterialTheme.typography.bodySmall)
     }
@@ -35,6 +108,7 @@ private class FakeDetailPresenter : DetailPresenter {
   private val _s = MutableStateFlow(DetailState(title = "Preview", content = "Content"))
   override val state: StateFlow<DetailState> = _s
   override fun initOnce(params: Int) {}
+  override fun translate(word: String) {}
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Summary
- support translating words via ArticleRepo
- highlight words under finger and animate "liquid glass" overlay
- expose translation API from DetailPresenter

## Testing
- `./gradlew :feature:catalog:impl:test` *(fails: build stuck during configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d44c21b88328899b74c601d4b1f0