### PR TITLE
Add task input field and fix app icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:name=".MyApp"
-        android:label="ComposeArchStarter">
+        android:label="ComposeArchStarter"
+        android:icon="@drawable/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/res/drawable/ic_launcher.xml
+++ b/app/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#FF0000"
+        android:pathData="M0,0h48v48h-48z" />
+</vector>

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -4,13 +4,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
+import androidx.compose.material3.TextField
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,7 +34,17 @@ fun CatalogScreen(
   val p = presenter ?: rememberPresenter<CatalogPresenter, Unit>()
   val state by p.state.collectAsStateWithLifecycle()
   Column(Modifier.padding(16.dp)) {
+    var taskInput by remember { mutableStateOf("") }
     Text("Catalog", style = MaterialTheme.typography.titleLarge)
+    Spacer(Modifier.height(8.dp))
+    TextField(
+      value = taskInput,
+      onValueChange = { taskInput = it },
+      label = { Text("Task") },
+      modifier = Modifier.fillMaxWidth()
+    )
+    Spacer(Modifier.height(8.dp))
+    Button(onClick = { /* no-op for now */ }) { Text("Add Task") }
     Spacer(Modifier.height(8.dp))
     Button(onClick = p::onSettingsClick) { Text("Settings") }
     Spacer(Modifier.height(8.dp))


### PR DESCRIPTION
## Summary
- add task text field with button to Catalog screen
- replace missing app icon with vector and wire it in manifest

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c458c7d88328b61ca8144973e745