### PR TITLE
Handle Room downgrades destructively

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
@@ -142,7 +142,10 @@ object ArticleDataModule {
   @Provides
   @Singleton
   fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
-    Room.databaseBuilder(context, AppDatabase::class.java, "articles.db").build()
+    Room.databaseBuilder(context, AppDatabase::class.java, "articles.db")
+      .fallbackToDestructiveMigration(dropAllTables = true)
+      .fallbackToDestructiveMigrationOnDowngrade(dropAllTables = true)
+      .build()
 
   @Provides
   fun provideArticleDao(db: AppDatabase): ArticleDao = db.articleDao()


### PR DESCRIPTION
## Summary
- ensure the articles database falls back to destructive migrations on upgrades and downgrades so missing migrations no longer crash the app

## Testing
- ./gradlew :feature:catalog:impl:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cafd61f3a08328a1ebd13f13931fc0