### PR TITLE
Handle translator API errors with AI fallback

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleNetwork.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleNetwork.kt
@@ -31,7 +31,11 @@ interface SummarizerService {
 }
 
 @Serializable
-data class TranslationResponse(@SerialName("responseData") val responseData: TranslationData)
+data class TranslationResponse(
+  @SerialName("responseData") val responseData: TranslationData,
+  @SerialName("responseStatus") val responseStatus: Int = 200,
+  @SerialName("responseDetails") val responseDetails: String? = null
+)
 @Serializable
 data class TranslationData(@SerialName("translatedText") val translatedText: String)
 


### PR DESCRIPTION
## Summary
- capture the MyMemory response status so API errors can be detected
- add a translation fallback that prompts the Pollinations endpoint for JSON when the API fails or returns blanks
- extend the repository tests to cover the new AI fallback behaviour

## Testing
- `./gradlew --no-daemon --console=plain feature:catalog:impl:test`


------
https://chatgpt.com/codex/tasks/task_e_68cc4f1dfcd083289b8f9794f9357c32