### PR TITLE
Persist selected languages across restarts

### DIFF
--- a/feature/settings/impl/build.gradle.kts
+++ b/feature/settings/impl/build.gradle.kts
@@ -20,6 +20,7 @@ android {
 dependencies {
   implementation(project(":feature:settings:api"))
   implementation(project(":core:common"))
+  implementation(libs.androidx.datastore.preferences)
 
   implementation(libs.hilt.android)
   ksp(libs.hilt.compiler)

--- a/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/data/SettingsRepository.kt
+++ b/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/data/SettingsRepository.kt
@@ -1,21 +1,74 @@
 package com.archstarter.feature.settings.impl.data
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.archstarter.feature.settings.api.SettingsState
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 @Singleton
-class SettingsRepository @Inject constructor() {
-    private val _state = MutableStateFlow(SettingsState())
-    val state: StateFlow<SettingsState> = _state
+class SettingsRepository @Inject constructor(
+    @ApplicationContext context: Context,
+) {
+    private val dataStore: DataStore<Preferences> = context.settingsDataStore
+    private val defaultState = SettingsState()
+    private val _state = MutableStateFlow(defaultState)
+    val state: StateFlow<SettingsState> = _state.asStateFlow()
+
+    private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }
+            .onEach { preferences ->
+                val native = preferences[NATIVE_LANGUAGE_KEY] ?: defaultState.nativeLanguage
+                val learning = preferences[LEARNING_LANGUAGE_KEY] ?: defaultState.learningLanguage
+                _state.value = SettingsState(nativeLanguage = native, learningLanguage = learning)
+            }
+            .launchIn(repositoryScope)
+    }
 
     suspend fun updateNative(language: String) {
-        _state.value = _state.value.copy(nativeLanguage = language)
+        _state.update { current -> current.copy(nativeLanguage = language) }
+        dataStore.edit { preferences ->
+            preferences[NATIVE_LANGUAGE_KEY] = language
+        }
     }
 
     suspend fun updateLearning(language: String) {
-        _state.value = _state.value.copy(learningLanguage = language)
+        _state.update { current -> current.copy(learningLanguage = language) }
+        dataStore.edit { preferences ->
+            preferences[LEARNING_LANGUAGE_KEY] = language
+        }
+    }
+
+    private companion object {
+        val NATIVE_LANGUAGE_KEY = stringPreferencesKey("native_language")
+        val LEARNING_LANGUAGE_KEY = stringPreferencesKey("learning_language")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ okhttp = "4.12.0"
 room = "2.7.2"
 ksp = "2.0.21-1.0.27"
 kotlinSerialization = "1.7.3"
+datastore = "1.1.1"
 
 [plugins]
 android-app = { id = "com.android.application", version.ref = "agp" }
@@ -53,3 +54,4 @@ okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
## Summary
- persist the settings state by backing `SettingsRepository` with DataStore and reloading saved selections on startup
- add the AndroidX DataStore dependency required for persisting language choices

## Testing
- ./gradlew :feature:settings:impl:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cd7c36420c83289dfbc5ec45f52a60