### PR TITLE
Translate articles into the from language

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
@@ -61,14 +61,14 @@ class ArticleRepository @Inject constructor(
     val original = words.randomOrNull() ?: return
 
     val state = settings.state.value
-    val targetCode = languageCodes[state.learningLanguage] ?: return
+    val targetCode = languageCodes[state.nativeLanguage] ?: return
     val sourceCode = languageCodes[DEFAULT_ARTICLE_LANGUAGE] ?: return
     val langPair = "$sourceCode|$targetCode"
     val translation = translateWithFallback(
       word = original,
       langPair = langPair,
       sourceLanguage = DEFAULT_ARTICLE_LANGUAGE,
-      targetLanguage = state.learningLanguage
+      targetLanguage = state.nativeLanguage
     ) ?: return
 
     val ipa = runCatching {
@@ -94,14 +94,14 @@ class ArticleRepository @Inject constructor(
 
   override suspend fun translate(word: String): String? {
     val state = settings.state.value
-    val targetCode = languageCodes[state.learningLanguage] ?: return null
+    val targetCode = languageCodes[state.nativeLanguage] ?: return null
     val sourceCode = languageCodes[DEFAULT_ARTICLE_LANGUAGE] ?: return null
     val langPair = "$sourceCode|$targetCode"
     return translateWithFallback(
       word = word,
       langPair = langPair,
       sourceLanguage = DEFAULT_ARTICLE_LANGUAGE,
-      targetLanguage = state.learningLanguage
+      targetLanguage = state.nativeLanguage
     )
   }
 

--- a/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/ArticleRepositoryTest.kt
+++ b/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/ArticleRepositoryTest.kt
@@ -46,7 +46,7 @@ class ArticleRepositoryTest {
   }
 
   @Test
-  fun translateUsesEnglishToLearningLangPair() = runTest {
+  fun translateUsesEnglishToNativeLangPair() = runTest {
     val dao = FakeArticleDao()
     var usedLangPair: String? = null
     val repo = ArticleRepository(
@@ -65,12 +65,12 @@ class ArticleRepositoryTest {
 
     val result = repo.translate("word")
 
-    assertEquals("en|es", usedLangPair)
+    assertEquals("en|en", usedLangPair)
     assertEquals("hola", result)
   }
 
   @Test
-  fun translateIgnoresNativeLanguageForSource() = runTest {
+  fun translateUsesNativeLanguageForTarget() = runTest {
     val dao = FakeArticleDao()
     var usedLangPair: String? = null
     val settings = SettingsRepository()
@@ -92,7 +92,7 @@ class ArticleRepositoryTest {
 
     repo.translate("word")
 
-    assertEquals("en|de", usedLangPair)
+    assertEquals("en|sr", usedLangPair)
   }
 
   @Test
@@ -118,7 +118,7 @@ class ArticleRepositoryTest {
   }
 
   @Test
-  fun refreshUsesEnglishToLearningLangPair() = runTest {
+  fun refreshUsesEnglishToNativeLangPair() = runTest {
     val dao = FakeArticleDao()
     var usedLangPair: String? = null
     val repo = ArticleRepository(
@@ -137,11 +137,11 @@ class ArticleRepositoryTest {
 
     repo.refresh()
 
-    assertEquals("en|es", usedLangPair)
+    assertEquals("en|en", usedLangPair)
   }
 
   @Test
-  fun refreshIgnoresCustomNativeLanguageForSource() = runTest {
+  fun refreshUsesNativeLanguageForTarget() = runTest {
     val dao = FakeArticleDao()
     var usedLangPair: String? = null
     val settings = SettingsRepository()
@@ -163,7 +163,7 @@ class ArticleRepositoryTest {
 
     repo.refresh()
 
-    assertEquals("en|de", usedLangPair)
+    assertEquals("en|fr", usedLangPair)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- send article translations and word lookups to the configured native ("from") language instead of the learning language
- update catalog repository unit tests to reflect the new translation target

## Testing
- ./gradlew feature:catalog:impl:test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cd7c7ff66c832886cac9cac2f2f968