### PR TITLE
Translate articles to native language and update tests

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleRepository.kt
@@ -22,12 +22,15 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 import javax.inject.Inject
 import com.archstarter.feature.settings.api.languageCodes
 import com.archstarter.feature.settings.impl.data.SettingsRepository
+import java.util.Locale
 
-private const val DEFAULT_ARTICLE_LANGUAGE = "English"
 private const val HTTP_OK = 200
 
 @Serializable
 private data class AiTranslation(val translatedText: String)
+
+@Serializable
+private data class AiLanguageDetection(val languageCode: String)
 
 private val fallbackJson = Json { ignoreUnknownKeys = true }
 
@@ -57,33 +60,73 @@ class ArticleRepository @Inject constructor(
       .getOrElse { return }
       .takeIf { it.isNotBlank() } ?: return
 
-    val words = summary.extract.split("\\W+".toRegex()).filter { it.length > 3 }
-    val original = words.randomOrNull() ?: return
-
     val state = settings.state.value
-    val targetCode = languageCodes[state.learningLanguage] ?: return
-    val sourceCode = languageCodes[DEFAULT_ARTICLE_LANGUAGE] ?: return
-    val langPair = "$sourceCode|$targetCode"
-    val translation = translateWithFallback(
-      word = original,
-      langPair = langPair,
-      sourceLanguage = DEFAULT_ARTICLE_LANGUAGE,
-      targetLanguage = state.learningLanguage
-    ) ?: return
+    val nativeLanguage = state.nativeLanguage
+    val learningLanguage = state.learningLanguage
+    val nativeCode = languageCodes[nativeLanguage] ?: return
+    val learningCode = languageCodes[learningLanguage] ?: return
 
-    val ipa = runCatching {
-      dictionary.lookup(original).firstOrNull()?.phonetics?.firstOrNull()?.text
-    }.getOrNull()
+    val detectedCode = detectLanguageCode(summary.extract)
+    val sourceCode = detectedCode ?: nativeCode
+    val sourceLanguage = languageDisplayName(sourceCode)
 
-    val replaced = summary.extract.replaceFirst(original, "$translation ($original)")
+    val translatedSummary = if (sourceCode == nativeCode) {
+      summaryText
+    } else {
+      translateWithFallback(
+        word = summaryText,
+        langPair = "$sourceCode|$nativeCode",
+        sourceLanguage = sourceLanguage,
+        targetLanguage = nativeLanguage
+      ) ?: return
+    }
+
+    val translatedContent = if (sourceCode == nativeCode) {
+      summary.extract
+    } else {
+      translateWithFallback(
+        word = summary.extract,
+        langPair = "$sourceCode|$nativeCode",
+        sourceLanguage = sourceLanguage,
+        targetLanguage = nativeLanguage
+      ) ?: return
+    }
+
+    val words = translatedContent.split("\\W+".toRegex()).filter { it.length > 3 }
+    val nativeWord = words.randomOrNull() ?: return
+
+    val learningTranslation = if (nativeCode == learningCode) {
+      nativeWord
+    } else {
+      translateWithFallback(
+        word = nativeWord,
+        langPair = "$nativeCode|$learningCode",
+        sourceLanguage = nativeLanguage,
+        targetLanguage = learningLanguage
+      ) ?: return
+    }
+
+    val ipa = if (nativeCode == "en") {
+      runCatching {
+        dictionary.lookup(nativeWord).firstOrNull()?.phonetics?.firstOrNull()?.text
+      }.getOrNull()
+    } else {
+      null
+    }
+
+    val replaced = if (learningTranslation == nativeWord) {
+      translatedContent
+    } else {
+      translatedContent.replaceFirst(nativeWord, "$nativeWord ($learningTranslation)")
+    }
     val entity = ArticleEntity(
       id = summary.pageid,
       title = summary.title,
-      summary = summaryText,
+      summary = translatedSummary,
       content = replaced,
       sourceUrl = summary.contentUrls.desktop.page,
-      originalWord = original,
-      translatedWord = translation,
+      originalWord = nativeWord,
+      translatedWord = learningTranslation,
       ipa = ipa,
       createdAt = System.currentTimeMillis()
     )
@@ -94,14 +137,17 @@ class ArticleRepository @Inject constructor(
 
   override suspend fun translate(word: String): String? {
     val state = settings.state.value
-    val targetCode = languageCodes[state.learningLanguage] ?: return null
-    val sourceCode = languageCodes[DEFAULT_ARTICLE_LANGUAGE] ?: return null
-    val langPair = "$sourceCode|$targetCode"
+    val nativeLanguage = state.nativeLanguage
+    val learningLanguage = state.learningLanguage
+    val nativeCode = languageCodes[nativeLanguage] ?: return null
+    val learningCode = languageCodes[learningLanguage] ?: return null
+    if (nativeCode == learningCode) return word
+    val langPair = "$nativeCode|$learningCode"
     return translateWithFallback(
       word = word,
       langPair = langPair,
-      sourceLanguage = DEFAULT_ARTICLE_LANGUAGE,
-      targetLanguage = state.learningLanguage
+      sourceLanguage = nativeLanguage,
+      targetLanguage = learningLanguage
     )
   }
 
@@ -121,9 +167,9 @@ class ArticleRepository @Inject constructor(
     if (translation != null) return translation
 
     val prompt = buildString {
-      appendLine("Translate the following word from $sourceLanguage to $targetLanguage.")
+      appendLine("Translate the following text from $sourceLanguage to $targetLanguage.")
       appendLine("Respond ONLY with valid JSON using this schema: {\"translatedText\":\"<translation>\"}.")
-      append("Word: $word")
+      append("Text: $word")
     }
 
     val fallback = runCatching {
@@ -132,6 +178,30 @@ class ArticleRepository @Inject constructor(
     }.getOrNull()
 
     return fallback?.takeIf { it.isNotBlank() }
+  }
+
+  private suspend fun detectLanguageCode(text: String): String? {
+    val sample = text.trim().take(1000)
+    if (sample.isBlank()) return null
+    val prompt = buildString {
+      appendLine("Identify the ISO 639-1 language code (two letters) for the following text.")
+      appendLine("Respond ONLY with valid JSON using this schema: {\"languageCode\":\"<code>\"}.")
+      appendLine("Text:")
+      append(sample)
+    }
+
+    return runCatching {
+      val response = retry { summarizer.summarize(prompt) }
+      fallbackJson.decodeFromString<AiLanguageDetection>(response).languageCode
+        .lowercase(Locale.ENGLISH)
+    }.getOrNull()?.takeIf { it.length == 2 }
+  }
+
+  private fun languageDisplayName(code: String): String {
+    val mapped = languageCodes.entries.firstOrNull { it.value.equals(code, ignoreCase = true) }?.key
+    if (mapped != null) return mapped
+    val localeName = Locale(code).getDisplayLanguage(Locale.ENGLISH)
+    return if (localeName.isBlank()) code else localeName
   }
 
   private suspend fun <T> retry(times: Int = 3, block: suspend () -> T): T {

--- a/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
+++ b/feature/settings/api/src/main/kotlin/com/archstarter/feature/settings/api/SettingsContracts.kt
@@ -25,6 +25,10 @@ data class SettingsState(
     val learningLanguage: String = "Spanish"
 )
 
+interface SettingsStateProvider {
+    val state: StateFlow<SettingsState>
+}
+
 interface SettingsPresenter: ParamInit<Unit> {
     val state: StateFlow<SettingsState>
     fun onNativeSelected(language: String)

--- a/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/data/SettingsRepository.kt
+++ b/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/data/SettingsRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.archstarter.feature.settings.api.SettingsState
+import com.archstarter.feature.settings.api.SettingsStateProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.IOException
 import javax.inject.Inject
@@ -28,11 +29,11 @@ private val Context.settingsDataStore: DataStore<Preferences> by preferencesData
 @Singleton
 class SettingsRepository @Inject constructor(
     @ApplicationContext context: Context,
-) {
+) : SettingsStateProvider {
     private val dataStore: DataStore<Preferences> = context.settingsDataStore
     private val defaultState = SettingsState()
     private val _state = MutableStateFlow(defaultState)
-    val state: StateFlow<SettingsState> = _state.asStateFlow()
+    override val state: StateFlow<SettingsState> = _state.asStateFlow()
 
     private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 


### PR DESCRIPTION
## Summary
- detect the article language with the summarizer and translate summaries/content into the selected native ("from") language
- translate highlighted words from the native language into the learning ("to") language and avoid duplicate hints when both languages match
- update the catalog repository tests to cover language detection, translation pairs, and the new article flow

## Testing
- `./gradlew :feature:catalog:impl:test --console=plain` *(fails: Installed Build Tools revision 35.0.0 is corrupted in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cda3429b608328b4e0817169f80090