### PR TITLE
Make catalog actions float with liquid glass overlay

### DIFF
--- a/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlass.kt
+++ b/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlass.kt
@@ -29,12 +29,14 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.max
 
+private const val MAX_GLASSES = 6
+
 private const val LIQUID_GLASS_AGSL = """
 uniform shader background;
 
 uniform float2 u_size;
-uniform float2 u_center;
-uniform float2 u_rectSize;
+uniform float  u_rectCount;
+uniform float4 u_rects[${MAX_GLASSES}];
 uniform float  u_radius;
 uniform float  u_bezel;
 uniform float  u_scale;
@@ -60,20 +62,41 @@ float dHeightDx(float x, float profile) {
 }
 
 half4 main(float2 coord) {
-    float2 p = coord - u_center;
-    float2 halfWH = 0.5 * u_rectSize;
-    float sdf = sdRoundRect(p, halfWH, u_radius);
-    if (sdf > 0.0) {
+    float bestSdf = 1e9;
+    float2 bestCenter = float2(0.0);
+    float2 bestHalfWH = float2(0.0);
+    bool hasHit = false;
+
+    for (int i = 0; i < ${MAX_GLASSES}; ++i) {
+        if (float(i) >= u_rectCount) {
+            break;
+        }
+        float4 packed = u_rects[i];
+        float2 center = packed.xy;
+        float2 halfWH = 0.5 * packed.zw;
+        float2 p = coord - center;
+        float sdf = sdRoundRect(p, halfWH, u_radius);
+        if (sdf <= 0.0 && sdf < bestSdf) {
+            bestSdf = sdf;
+            bestCenter = center;
+            bestHalfWH = halfWH;
+            hasHit = true;
+        }
+    }
+
+    if (!hasHit) {
         return background.eval(coord);
     }
+
+    float2 p = coord - bestCenter;
     float eps = 1.0;
-    float sx = sdRoundRect(p + float2(eps, 0.0), halfWH, u_radius) -
-               sdRoundRect(p - float2(eps, 0.0), halfWH, u_radius);
-    float sy = sdRoundRect(p + float2(0.0, eps), halfWH, u_radius) -
-               sdRoundRect(p - float2(0.0, eps), halfWH, u_radius);
+    float sx = sdRoundRect(p + float2(eps, 0.0), bestHalfWH, u_radius) -
+               sdRoundRect(p - float2(eps, 0.0), bestHalfWH, u_radius);
+    float sy = sdRoundRect(p + float2(0.0, eps), bestHalfWH, u_radius) -
+               sdRoundRect(p - float2(0.0, eps), bestHalfWH, u_radius);
     float2 n = normalize(float2(sx, sy));
     float2 inwardN = -n;
-    float d = clamp(-sdf, 0.0, u_bezel);
+    float d = clamp(-bestSdf, 0.0, u_bezel);
     float x = (u_bezel > 0.0) ? (d / u_bezel) : 0.0;
     float slope = dHeightDx(x, u_profile);
     float bend = slope * (1.0 - 1.0 / max(u_ri, 1.0001));
@@ -116,25 +139,52 @@ fun LiquidGlassRectOverlay(
     spec: LiquidGlassSpec = LiquidGlassSpec(),
     content: @Composable BoxScope.() -> Unit,
 ) {
+    LiquidGlassRectOverlay(
+        rects = rect?.let(::listOf).orEmpty(),
+        modifier = modifier,
+        spec = spec,
+        content = content,
+    )
+}
+
+@Composable
+fun LiquidGlassRectOverlay(
+    rects: List<LiquidGlassRect>,
+    modifier: Modifier = Modifier,
+    spec: LiquidGlassSpec = LiquidGlassSpec(),
+    content: @Composable BoxScope.() -> Unit,
+) {
     val density = LocalDensity.current
     var containerSize by remember { mutableStateOf(Size.Zero) }
     val shader = remember {
         if (Build.VERSION.SDK_INT >= 33) RuntimeShader(LIQUID_GLASS_AGSL) else null
     }
-    val rectPx = remember(rect, density) {
-        rect?.takeUnless { it.isEmpty }?.toRect(density)
+    val rectsPx = remember(rects, density) {
+        rects
+            .filterNot { it.isEmpty }
+            .map { it.toRect(density) }
     }
 
-    LaunchedEffect(rectPx, containerSize, spec, density, shader) {
+    LaunchedEffect(rectsPx, containerSize, spec, density, shader) {
         if (Build.VERSION.SDK_INT < 33) return@LaunchedEffect
         val runtimeShader = shader ?: return@LaunchedEffect
-        val r = rectPx ?: return@LaunchedEffect
+        if (rectsPx.isEmpty()) return@LaunchedEffect
         if (containerSize.width <= 0f || containerSize.height <= 0f) return@LaunchedEffect
         val corner = with(density) { spec.cornerRadius.toPx() }
         val bezel = with(density) { spec.bezelWidth.toPx() }
         runtimeShader.setFloatUniform("u_size", containerSize.width, containerSize.height)
-        runtimeShader.setFloatUniform("u_center", r.center.x, r.center.y)
-        runtimeShader.setFloatUniform("u_rectSize", r.width, r.height)
+        val count = rectsPx.size.coerceAtMost(MAX_GLASSES)
+        runtimeShader.setFloatUniform("u_rectCount", count.toFloat())
+        val rectBuffer = FloatArray(MAX_GLASSES * 4)
+        for (i in 0 until count) {
+            val rect = rectsPx[i]
+            val base = i * 4
+            rectBuffer[base] = rect.center.x
+            rectBuffer[base + 1] = rect.center.y
+            rectBuffer[base + 2] = rect.width
+            rectBuffer[base + 3] = rect.height
+        }
+        runtimeShader.setFloatUniform("u_rects", rectBuffer)
         runtimeShader.setFloatUniform("u_radius", corner)
         runtimeShader.setFloatUniform("u_bezel", max(1f, bezel))
         runtimeShader.setFloatUniform("u_scale", spec.displacementScalePx)
@@ -143,8 +193,8 @@ fun LiquidGlassRectOverlay(
         runtimeShader.setFloatUniform("u_highlight", spec.highlight)
     }
 
-    val renderEffect = remember(rectPx, shader) {
-        if (Build.VERSION.SDK_INT >= 33 && shader != null && rectPx != null) {
+    val renderEffect = remember(rectsPx, shader) {
+        if (Build.VERSION.SDK_INT >= 33 && shader != null && rectsPx.isNotEmpty()) {
             RenderEffect
                 .createRuntimeShaderEffect(shader, "background")
                 .asComposeRenderEffect()
@@ -169,8 +219,8 @@ fun LiquidGlassRectOverlay(
             .then(layerModifier)
             .drawWithContent {
                 drawContent()
-                if ((Build.VERSION.SDK_INT < 33 || shader == null) && rectPx != null) {
-                    drawFallbackGlass(rectPx, spec)
+                if ((Build.VERSION.SDK_INT < 33 || shader == null) && rectsPx.isNotEmpty()) {
+                    drawFallbackGlass(rectsPx, spec)
                 }
             }
     ) {
@@ -186,19 +236,23 @@ private fun LiquidGlassRect.toRect(density: Density): Rect = with(density) {
     Rect(leftPx, topPx, leftPx + widthPx, topPx + heightPx)
 }
 
-private fun DrawScope.drawFallbackGlass(rect: Rect, spec: LiquidGlassSpec) {
+private fun DrawScope.drawFallbackGlass(rects: List<Rect>, spec: LiquidGlassSpec) {
     val corner = androidx.compose.ui.geometry.CornerRadius(spec.cornerRadius.toPx())
-    drawRoundRect(
-        color = Color.White.copy(alpha = 0.06f),
-        topLeft = Offset(rect.left, rect.top),
-        size = Size(rect.width, rect.height),
-        cornerRadius = corner
-    )
-    drawRoundRect(
-        color = Color.White.copy(alpha = 0.10f),
-        topLeft = Offset(rect.left, rect.top),
-        size = Size(rect.width, rect.height),
-        cornerRadius = corner
-    )
+    rects.forEach { rect ->
+        val topLeft = Offset(rect.left, rect.top)
+        val size = Size(rect.width, rect.height)
+        drawRoundRect(
+            color = Color.White.copy(alpha = 0.06f),
+            topLeft = topLeft,
+            size = size,
+            cornerRadius = corner
+        )
+        drawRoundRect(
+            color = Color.White.copy(alpha = 0.10f),
+            topLeft = topLeft,
+            size = size,
+            cornerRadius = corner
+        )
+    }
 }
 

--- a/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlass.kt
+++ b/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlass.kt
@@ -29,18 +29,22 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.max
 
-private const val LIQUID_GLASS_AGSL = """
+private const val MAX_RUNTIME_SHADER_RECTS = 6
+
+private val LIQUID_GLASS_AGSL = """
 uniform shader background;
 
+const int MAX_RECTS = $MAX_RUNTIME_SHADER_RECTS;
+
 uniform float2 u_size;
-uniform float2 u_center;
-uniform float2 u_rectSize;
 uniform float  u_radius;
 uniform float  u_bezel;
 uniform float  u_scale;
 uniform float  u_ri;
 uniform float  u_profile;
 uniform float  u_highlight;
+uniform float4 u_rectData[MAX_RECTS];
+uniform int    u_rectCount;
 
 float sdRoundRect(float2 p, float2 halfWH, float r) {
     float2 q = abs(p) - (halfWH - float2(r));
@@ -60,12 +64,43 @@ float dHeightDx(float x, float profile) {
 }
 
 half4 main(float2 coord) {
-    float2 p = coord - u_center;
-    float2 halfWH = 0.5 * u_rectSize;
-    float sdf = sdRoundRect(p, halfWH, u_radius);
-    if (sdf > 0.0) {
+    if (u_rectCount <= 0) {
         return background.eval(coord);
     }
+
+    float minSdf = 1e9;
+    float2 activeCenter = float2(0.0);
+    float2 activeRectSize = float2(0.0);
+    int activeIndex = -1;
+
+    for (int i = 0; i < MAX_RECTS; ++i) {
+        if (i >= u_rectCount) {
+            break;
+        }
+        float4 data = u_rectData[i];
+        float2 center = float2(data.x, data.y);
+        float2 rectSize = float2(data.z, data.w);
+        if (rectSize.x <= 0.0 || rectSize.y <= 0.0) {
+            continue;
+        }
+        float2 p = coord - center;
+        float2 halfWH = 0.5 * rectSize;
+        float sdf = sdRoundRect(p, halfWH, u_radius);
+        if (sdf < minSdf) {
+            minSdf = sdf;
+            activeCenter = center;
+            activeRectSize = rectSize;
+            activeIndex = i;
+        }
+    }
+
+    if (activeIndex < 0 || minSdf > 0.0) {
+        return background.eval(coord);
+    }
+
+    float2 p = coord - activeCenter;
+    float2 halfWH = 0.5 * activeRectSize;
+    float sdf = minSdf;
     float eps = 1.0;
     float sx = sdRoundRect(p + float2(eps, 0.0), halfWH, u_radius) -
                sdRoundRect(p - float2(eps, 0.0), halfWH, u_radius);
@@ -111,7 +146,7 @@ data class LiquidGlassRect(
 
 @Composable
 fun LiquidGlassRectOverlay(
-    rect: LiquidGlassRect?,
+    rects: List<LiquidGlassRect>,
     modifier: Modifier = Modifier,
     spec: LiquidGlassSpec = LiquidGlassSpec(),
     content: @Composable BoxScope.() -> Unit,
@@ -121,30 +156,48 @@ fun LiquidGlassRectOverlay(
     val shader = remember {
         if (Build.VERSION.SDK_INT >= 33) RuntimeShader(LIQUID_GLASS_AGSL) else null
     }
-    val rectPx = remember(rect, density) {
-        rect?.takeUnless { it.isEmpty }?.toRect(density)
+    val rectsPx = remember(rects, density) {
+        rects.mapNotNull { rect ->
+            rect.takeUnless { it.isEmpty }?.toRect(density)
+        }
+    }
+    val limitedRectsPx = remember(rectsPx) {
+        rectsPx.take(MAX_RUNTIME_SHADER_RECTS)
     }
 
-    LaunchedEffect(rectPx, containerSize, spec, density, shader) {
+    LaunchedEffect(limitedRectsPx, containerSize, spec, density, shader) {
         if (Build.VERSION.SDK_INT < 33) return@LaunchedEffect
         val runtimeShader = shader ?: return@LaunchedEffect
-        val r = rectPx ?: return@LaunchedEffect
+        if (limitedRectsPx.isEmpty()) return@LaunchedEffect
         if (containerSize.width <= 0f || containerSize.height <= 0f) return@LaunchedEffect
         val corner = with(density) { spec.cornerRadius.toPx() }
         val bezel = with(density) { spec.bezelWidth.toPx() }
         runtimeShader.setFloatUniform("u_size", containerSize.width, containerSize.height)
-        runtimeShader.setFloatUniform("u_center", r.center.x, r.center.y)
-        runtimeShader.setFloatUniform("u_rectSize", r.width, r.height)
         runtimeShader.setFloatUniform("u_radius", corner)
         runtimeShader.setFloatUniform("u_bezel", max(1f, bezel))
         runtimeShader.setFloatUniform("u_scale", spec.displacementScalePx)
         runtimeShader.setFloatUniform("u_ri", spec.refractiveIndex)
         runtimeShader.setFloatUniform("u_profile", spec.profile)
         runtimeShader.setFloatUniform("u_highlight", spec.highlight)
+        runtimeShader.setIntUniform("u_rectCount", limitedRectsPx.size)
+        for (i in 0 until MAX_RUNTIME_SHADER_RECTS) {
+            if (i < limitedRectsPx.size) {
+                val rect = limitedRectsPx[i]
+                runtimeShader.setFloatUniform(
+                    "u_rectData[$i]",
+                    rect.center.x,
+                    rect.center.y,
+                    rect.width,
+                    rect.height,
+                )
+            } else {
+                runtimeShader.setFloatUniform("u_rectData[$i]", 0f, 0f, 0f, 0f)
+            }
+        }
     }
 
-    val renderEffect = remember(rectPx, shader) {
-        if (Build.VERSION.SDK_INT >= 33 && shader != null && rectPx != null) {
+    val renderEffect = remember(limitedRectsPx, shader) {
+        if (Build.VERSION.SDK_INT >= 33 && shader != null && limitedRectsPx.isNotEmpty()) {
             RenderEffect
                 .createRuntimeShaderEffect(shader, "background")
                 .asComposeRenderEffect()
@@ -169,8 +222,8 @@ fun LiquidGlassRectOverlay(
             .then(layerModifier)
             .drawWithContent {
                 drawContent()
-                if ((Build.VERSION.SDK_INT < 33 || shader == null) && rectPx != null) {
-                    drawFallbackGlass(rectPx, spec)
+                if ((Build.VERSION.SDK_INT < 33 || shader == null) && limitedRectsPx.isNotEmpty()) {
+                    drawFallbackGlass(limitedRectsPx, spec)
                 }
             }
     ) {
@@ -186,19 +239,21 @@ private fun LiquidGlassRect.toRect(density: Density): Rect = with(density) {
     Rect(leftPx, topPx, leftPx + widthPx, topPx + heightPx)
 }
 
-private fun DrawScope.drawFallbackGlass(rect: Rect, spec: LiquidGlassSpec) {
+private fun DrawScope.drawFallbackGlass(rects: List<Rect>, spec: LiquidGlassSpec) {
     val corner = androidx.compose.ui.geometry.CornerRadius(spec.cornerRadius.toPx())
-    drawRoundRect(
-        color = Color.White.copy(alpha = 0.06f),
-        topLeft = Offset(rect.left, rect.top),
-        size = Size(rect.width, rect.height),
-        cornerRadius = corner
-    )
-    drawRoundRect(
-        color = Color.White.copy(alpha = 0.10f),
-        topLeft = Offset(rect.left, rect.top),
-        size = Size(rect.width, rect.height),
-        cornerRadius = corner
-    )
+    rects.forEach { rect ->
+        drawRoundRect(
+            color = Color.White.copy(alpha = 0.06f),
+            topLeft = Offset(rect.left, rect.top),
+            size = Size(rect.width, rect.height),
+            cornerRadius = corner
+        )
+        drawRoundRect(
+            color = Color.White.copy(alpha = 0.10f),
+            topLeft = Offset(rect.left, rect.top),
+            size = Size(rect.width, rect.height),
+            cornerRadius = corner
+        )
+    }
 }
 

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -16,6 +17,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
@@ -103,7 +105,8 @@ fun CatalogScreen(
       rect.copy(left = rect.left + offsetX, top = rect.top + offsetY)
     }
   }
-  val settingsGlassRect = remember(settingsButtonOffset, settingsButtonSize, density) {
+  val buttonGlassTint = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+  val settingsGlassRect = remember(settingsButtonOffset, settingsButtonSize, density, buttonGlassTint) {
     val buttonOffset = settingsButtonOffset
     val buttonSize = settingsButtonSize
     if (buttonOffset == null || buttonSize == null) {
@@ -115,11 +118,12 @@ fun CatalogScreen(
           top = buttonOffset.y.toDp(),
           width = buttonSize.width.toDp(),
           height = buttonSize.height.toDp(),
+          tintColor = buttonGlassTint,
         )
       }
     }
   }
-  val refreshGlassRect = remember(refreshButtonOffset, refreshButtonSize, density) {
+  val refreshGlassRect = remember(refreshButtonOffset, refreshButtonSize, density, buttonGlassTint) {
     val buttonOffset = refreshButtonOffset
     val buttonSize = refreshButtonSize
     if (buttonOffset == null || buttonSize == null) {
@@ -131,6 +135,7 @@ fun CatalogScreen(
           top = buttonOffset.y.toDp(),
           width = buttonSize.width.toDp(),
           height = buttonSize.height.toDp(),
+          tintColor = buttonGlassTint,
         )
       }
     }
@@ -172,6 +177,18 @@ fun CatalogScreen(
     }
 
     val glassPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+    val transparentButtonColors = ButtonDefaults.buttonColors(
+      containerColor = Color.Transparent,
+      contentColor = MaterialTheme.colorScheme.onSurface,
+      disabledContainerColor = Color.Transparent,
+      disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+    )
+    val transparentButtonElevation = ButtonDefaults.buttonElevation(
+      defaultElevation = 0.dp,
+      pressedElevation = 0.dp,
+      focusedElevation = 0.dp,
+      hoveredElevation = 0.dp,
+    )
     Row(
       modifier = Modifier
         .align(Alignment.BottomCenter)
@@ -190,7 +207,11 @@ fun CatalogScreen(
         }
       ) {
         Box(modifier = Modifier.padding(glassPadding)) {
-          Button(onClick = p::onSettingsClick) { Text("Settings") }
+          Button(
+            onClick = p::onSettingsClick,
+            colors = transparentButtonColors,
+            elevation = transparentButtonElevation,
+          ) { Text("Settings") }
         }
       }
       Box(
@@ -200,7 +221,11 @@ fun CatalogScreen(
         }
       ) {
         Box(modifier = Modifier.padding(glassPadding)) {
-          Button(onClick = p::onRefresh) { Text("Refresh (${state.items.size})") }
+          Button(
+            onClick = p::onRefresh,
+            colors = transparentButtonColors,
+            elevation = transparentButtonElevation,
+          ) { Text("Refresh (${state.items.size})") }
         }
       }
     }

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -136,57 +136,38 @@ fun CatalogScreen(
     }
   }
   val listBottomPadding = 32.dp + bottomControlsHeight
+  val glassRects = remember(centerGlassRect, settingsGlassRect, refreshGlassRect) {
+    listOfNotNull(centerGlassRect, settingsGlassRect, refreshGlassRect)
+  }
 
   Box(Modifier.fillMaxSize()) {
-    Column(
-      modifier = Modifier
-        .fillMaxSize()
-        .padding(horizontal = 16.dp, vertical = 16.dp)
+    LiquidGlassRectOverlay(
+      rects = glassRects,
+      modifier = Modifier.fillMaxSize()
     ) {
-      Text("Catalog", style = MaterialTheme.typography.titleLarge)
-      Spacer(Modifier.height(8.dp))
-      Box(
+      Column(
         modifier = Modifier
-          .weight(1f)
-          .onGloballyPositioned { coords -> viewportOffset = coords.positionInRoot() }
-          .onSizeChanged { viewportSize = it }
+          .fillMaxSize()
+          .padding(horizontal = 16.dp, vertical = 16.dp)
       ) {
-        LazyColumn(
-          state = listState,
-          contentPadding = PaddingValues(bottom = listBottomPadding),
-          verticalArrangement = Arrangement.spacedBy(8.dp)
+        Text("Catalog", style = MaterialTheme.typography.titleLarge)
+        Spacer(Modifier.height(8.dp))
+        Box(
+          modifier = Modifier
+            .weight(1f)
+            .onGloballyPositioned { coords -> viewportOffset = coords.positionInRoot() }
+            .onSizeChanged { viewportSize = it }
         ) {
-          items(state.items, key = { it }) { id ->
-            CatalogItemCard(id = id)
+          LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(bottom = listBottomPadding),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+          ) {
+            items(state.items, key = { it }) { id ->
+              CatalogItemCard(id = id)
+            }
           }
         }
-      }
-    }
-
-    centerGlassRect?.let { rect ->
-      LiquidGlassRectOverlay(
-        rect = rect,
-        modifier = Modifier.fillMaxSize()
-      ) {
-        Box(Modifier.fillMaxSize())
-      }
-    }
-
-    settingsGlassRect?.let { rect ->
-      LiquidGlassRectOverlay(
-        rect = rect,
-        modifier = Modifier.fillMaxSize()
-      ) {
-        Box(Modifier.fillMaxSize())
-      }
-    }
-
-    refreshGlassRect?.let { rect ->
-      LiquidGlassRectOverlay(
-        rect = rect,
-        modifier = Modifier.fillMaxSize()
-      ) {
-        Box(Modifier.fillMaxSize())
       }
     }
 

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -57,7 +57,8 @@ fun CatalogScreen(
       }
     }
   }
-  val targetGlassRect by remember {
+  val centerGlassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.65f)
+  val targetGlassRect by remember(centerGlassTint) {
     derivedStateOf {
       val info = centeredItemInfo ?: return@derivedStateOf null
       if (viewportSize.width == 0 || viewportSize.height == 0) return@derivedStateOf null
@@ -72,6 +73,7 @@ fun CatalogScreen(
           top = clampedTopPx.toDp(),
           width = viewportSize.width.toDp(),
           height = info.size.toDp(),
+          tintColor = centerGlassTint,
         )
       }
     }
@@ -105,7 +107,7 @@ fun CatalogScreen(
       rect.copy(left = rect.left + offsetX, top = rect.top + offsetY)
     }
   }
-  val buttonGlassTint = MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+  val buttonGlassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.55f)
   val settingsGlassRect = remember(settingsButtonOffset, settingsButtonSize, density, buttonGlassTint) {
     val buttonOffset = settingsButtonOffset
     val buttonSize = settingsButtonSize
@@ -176,7 +178,7 @@ fun CatalogScreen(
       }
     }
 
-    val glassPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+    val glassPadding = PaddingValues(horizontal = 16.dp, vertical = 6.dp)
     val transparentButtonColors = ButtonDefaults.buttonColors(
       containerColor = Color.Transparent,
       contentColor = MaterialTheme.colorScheme.onSurface,
@@ -192,7 +194,7 @@ fun CatalogScreen(
     Row(
       modifier = Modifier
         .align(Alignment.BottomCenter)
-        .padding(horizontal = 16.dp, vertical = 16.dp)
+        .padding(horizontal = 16.dp, vertical = 8.dp)
         .navigationBarsPadding()
         .onSizeChanged { size ->
           bottomControlsHeight = with(density) { size.height.toDp() }


### PR DESCRIPTION
## Summary
- move the catalog action buttons into a floating bottom overlay with a liquid glass effect
- derive the glass rectangle for the controls at runtime so the shader samples the background correctly
- give the list extra bottom padding so items remain visible under the floating controls

## Testing
- ./gradlew :feature:catalog:ui:lint --console=plain *(fails: Android SDK Build-Tools 35 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda4b81d6c8328916f4e1903066333