### PR TITLE
Cache hovered word translations in detail screen

### DIFF
--- a/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/DetailViewModelTest.kt
+++ b/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/DetailViewModelTest.kt
@@ -1,0 +1,120 @@
+package com.archstarter.feature.detail.impl
+
+import androidx.lifecycle.SavedStateHandle
+import com.archstarter.core.common.scope.ScreenBus
+import com.archstarter.feature.catalog.impl.data.ArticleEntity
+import com.archstarter.feature.catalog.impl.data.ArticleRepo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailViewModelTest {
+
+  @get:Rule val dispatcherRule = MainDispatcherRule()
+
+  @Test
+  fun translateReusesCachedTranslation() = runTest {
+    val article = sampleArticle()
+    val repo = FakeArticleRepo(article) { word, call -> "$word-$call" }
+    val vm = DetailViewModel(repo, ScreenBus(), SavedStateHandle())
+
+    vm.initOnce(article.id)
+    advanceUntilIdle()
+
+    vm.translate("Hover")
+    advanceUntilIdle()
+
+    assertEquals("Hover-1", vm.state.value.highlightedTranslation)
+    assertEquals(1, repo.translateCalls)
+
+    vm.translate("Hover")
+    advanceUntilIdle()
+
+    assertEquals("Hover-1", vm.state.value.highlightedTranslation)
+    assertEquals(1, repo.translateCalls)
+  }
+
+  @Test
+  fun translateUsesCachedArticleTranslation() = runTest {
+    val article = sampleArticle(original = "Original", translated = "Translated")
+    val repo = FakeArticleRepo(article) { word, call -> "$word-$call" }
+    val vm = DetailViewModel(repo, ScreenBus(), SavedStateHandle())
+
+    vm.initOnce(article.id)
+    advanceUntilIdle()
+
+    vm.translate("Original")
+    advanceUntilIdle()
+
+    assertEquals(0, repo.translateCalls)
+    assertEquals("Original", vm.state.value.highlightedWord)
+    assertEquals("Translated", vm.state.value.highlightedTranslation)
+  }
+
+  @Test
+  fun translateCachesAcrossWordCaseDifferences() = runTest {
+    val article = sampleArticle()
+    val repo = FakeArticleRepo(article) { word, call -> "$word-$call" }
+    val vm = DetailViewModel(repo, ScreenBus(), SavedStateHandle())
+
+    vm.initOnce(article.id)
+    advanceUntilIdle()
+
+    vm.translate("Word")
+    advanceUntilIdle()
+
+    assertEquals(1, repo.translateCalls)
+    assertEquals("Word-1", vm.state.value.highlightedTranslation)
+
+    vm.translate("word")
+    advanceUntilIdle()
+
+    assertEquals(1, repo.translateCalls)
+    assertEquals("Word-1", vm.state.value.highlightedTranslation)
+  }
+
+  private fun sampleArticle(
+    id: Int = 1,
+    title: String = "Title",
+    summary: String = "Summary",
+    content: String = "Content",
+    sourceUrl: String = "https://example.com",
+    original: String = "Original",
+    translated: String = "Translated",
+    ipa: String? = null,
+    createdAt: Long = 0L,
+  ) = ArticleEntity(
+    id = id,
+    title = title,
+    summary = summary,
+    content = content,
+    sourceUrl = sourceUrl,
+    originalWord = original,
+    translatedWord = translated,
+    ipa = ipa,
+    createdAt = createdAt,
+  )
+
+  private class FakeArticleRepo(
+    private val article: ArticleEntity?,
+    private val translationProvider: (String, Int) -> String?,
+  ) : ArticleRepo {
+    override val articles: StateFlow<List<ArticleEntity>> = MutableStateFlow(emptyList())
+    var translateCalls: Int = 0
+
+    override suspend fun refresh() {}
+
+    override suspend fun article(id: Int): ArticleEntity? = article
+
+    override suspend fun translate(word: String): String? {
+      translateCalls += 1
+      return translationProvider(word, translateCalls)
+    }
+  }
+}

--- a/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/MainDispatcherRule.kt
+++ b/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/MainDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.archstarter.feature.detail.impl
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+  private val dispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+  override fun starting(description: Description) {
+    Dispatchers.setMain(dispatcher)
+  }
+
+  override fun finished(description: Description) {
+    Dispatchers.resetMain()
+  }
+}


### PR DESCRIPTION
## Summary
- add an in-memory translation cache to `DetailViewModel` and seed it from the loaded article
- normalize words/translations before caching so repeated hovers reuse existing results
- add unit tests (with a dispatcher rule) that verify cached translations and case-insensitive reuse

## Testing
- ./gradlew :feature:detail:impl:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cda51979388328aa88a30230fce5cc