### PR TITLE
Lazy catalog summary translation

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleData.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleData.kt
@@ -15,6 +15,7 @@ data class ArticleEntity(
   @PrimaryKey val id: Int,
   val title: String,
   val summary: String,
+  val summaryLanguage: String?,
   val content: String,
   val sourceUrl: String,
   val originalWord: String,
@@ -29,13 +30,16 @@ interface ArticleDao {
   fun getArticles(): Flow<List<ArticleEntity>>
 
   @Query("SELECT * FROM articles WHERE id = :id")
+  fun observeArticle(id: Int): Flow<ArticleEntity?>
+
+  @Query("SELECT * FROM articles WHERE id = :id")
   suspend fun getArticle(id: Int): ArticleEntity?
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun insert(article: ArticleEntity)
 }
 
-@Database(entities = [ArticleEntity::class], version = 2)
+@Database(entities = [ArticleEntity::class], version = 3)
 abstract class AppDatabase : RoomDatabase() {
   abstract fun articleDao(): ArticleDao
 }

--- a/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/CatalogViewModelTest.kt
+++ b/feature/catalog/impl/src/test/java/com/archstarter/feature/catalog/impl/CatalogViewModelTest.kt
@@ -9,6 +9,7 @@ import com.archstarter.feature.catalog.impl.data.ArticleEntity
 import com.archstarter.feature.catalog.impl.data.ArticleRepo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -28,11 +29,13 @@ class CatalogViewModelTest {
       override val articles: StateFlow<List<ArticleEntity>> = data
       override suspend fun refresh() {
         data.value = listOf(
-          ArticleEntity(1,"One","S","C","u","o","t",null,0L),
-          ArticleEntity(2,"Two","S","C","u","o","t",null,1L)
+          ArticleEntity(1,"One","S",null,"C","u","o","t",null,0L),
+          ArticleEntity(2,"Two","S",null,"C","u","o","t",null,1L)
         )
       }
       override suspend fun article(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
+      override fun articleFlow(id: Int) = data.map { list -> list.firstOrNull { it.id == id } }
+      override suspend fun translateSummary(article: ArticleEntity): String? = article.summary
       override suspend fun translate(word: String): String? = word
     }
     val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }
@@ -57,10 +60,12 @@ class CatalogViewModelTest {
         refreshCount++
         val id = refreshCount
         data.value = listOf(
-          ArticleEntity(id, "Title$id", "S", "C", "u", "o", "t", null, id.toLong())
+          ArticleEntity(id, "Title$id", "S", null, "C", "u", "o", "t", null, id.toLong())
         ) + data.value
       }
       override suspend fun article(id: Int): ArticleEntity? = null
+      override fun articleFlow(id: Int) = data.map { list -> list.firstOrNull { it.id == id } }
+      override suspend fun translateSummary(article: ArticleEntity): String? = article.summary
       override suspend fun translate(word: String): String? = word
     }
     val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }
@@ -78,12 +83,14 @@ class CatalogViewModelTest {
   @Test
   fun initDoesNotFetchWhenArticlesAlreadyExist() = runTest {
     var refreshCount = 0
-    val existing = ArticleEntity(1, "One", "S", "C", "u", "o", "t", null, 0L)
+    val existing = ArticleEntity(1, "One", "S", null, "C", "u", "o", "t", null, 0L)
     val data = MutableStateFlow(listOf(existing))
     val repo = object : ArticleRepo {
       override val articles: StateFlow<List<ArticleEntity>> = data
       override suspend fun refresh() { refreshCount++ }
       override suspend fun article(id: Int): ArticleEntity? = data.value.firstOrNull { it.id == id }
+      override fun articleFlow(id: Int) = data.map { list -> list.firstOrNull { it.id == id } }
+      override suspend fun translateSummary(article: ArticleEntity): String? = article.summary
       override suspend fun translate(word: String): String? = word
     }
     val nav = object : NavigationActions { override fun openDetail(id: Int) {}; override fun openSettings() {} }

--- a/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/DetailViewModelTest.kt
+++ b/feature/detail/impl/src/test/java/com/archstarter/feature/detail/impl/DetailViewModelTest.kt
@@ -6,8 +6,10 @@ import com.archstarter.feature.catalog.impl.data.ArticleEntity
 import com.archstarter.feature.catalog.impl.data.ArticleRepo
 import java.util.Locale
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -104,6 +106,7 @@ class DetailViewModelTest {
     id: Int = 1,
     title: String = "Title",
     summary: String = "Summary",
+    summaryLanguage: String? = null,
     content: String = "Content",
     sourceUrl: String = "https://example.com",
     original: String = "Original",
@@ -114,6 +117,7 @@ class DetailViewModelTest {
     id = id,
     title = title,
     summary = summary,
+    summaryLanguage = summaryLanguage,
     content = content,
     sourceUrl = sourceUrl,
     originalWord = original,
@@ -132,6 +136,10 @@ class DetailViewModelTest {
     override suspend fun refresh() {}
 
     override suspend fun article(id: Int): ArticleEntity? = article
+
+    override fun articleFlow(id: Int): Flow<ArticleEntity?> = flowOf(article)
+
+    override suspend fun translateSummary(article: ArticleEntity): String? = article.summary
 
     override suspend fun translate(word: String): String? {
       translateCalls += 1


### PR DESCRIPTION
## Summary
- lazily translate catalog item summaries by driving state from a shared flow and updating once translations arrive
- persist summary language metadata, expose article flows, and add a repository helper to translate summaries on demand
- adjust repository and viewmodel tests for the new API and add coverage for summary translation using stored language codes

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cea88e590c8328bf19eae8d2e7d89f