### PR TITLE
Add persistent translation cache

### DIFF
--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleData.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/data/ArticleData.kt
@@ -39,7 +39,27 @@ interface ArticleDao {
   suspend fun insert(article: ArticleEntity)
 }
 
-@Database(entities = [ArticleEntity::class], version = 3)
+@Entity(tableName = "translations", primaryKeys = ["langPair", "normalizedText"])
+data class TranslationEntity(
+  val langPair: String,
+  val normalizedText: String,
+  val translation: String,
+  val updatedAt: Long,
+)
+
+@Dao
+interface TranslationDao {
+  @Query(
+    "SELECT * FROM translations WHERE langPair = :langPair AND normalizedText = :normalized LIMIT 1"
+  )
+  suspend fun translation(langPair: String, normalized: String): TranslationEntity?
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insert(entity: TranslationEntity)
+}
+
+@Database(entities = [ArticleEntity::class, TranslationEntity::class], version = 4)
 abstract class AppDatabase : RoomDatabase() {
   abstract fun articleDao(): ArticleDao
+  abstract fun translationDao(): TranslationDao
 }


### PR DESCRIPTION
## Summary
- add a Room entity/DAO for cached translations and expose it from the database
- persist and reuse translations in `ArticleRepository`, including DI wiring
- expand repository tests with fakes and new cases covering the database cache

## Testing
- `./gradlew test --console=plain` *(fails: Android build tools dependency `core-lambda-stubs.jar` missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec17f6f648328ad4c7808352874bc