### PR TITLE
Increase detail screen typography

### DIFF
--- a/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
+++ b/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -77,7 +78,7 @@ fun DetailScreen(id: Int, presenter: DetailPresenter? = null) {
   }
 
   Column(Modifier.padding(16.dp)) {
-    Text(state.title, style = MaterialTheme.typography.titleLarge)
+    Text(state.title, style = MaterialTheme.typography.headlineSmall)
     val content = state.content
     val words = remember(content) { content.toWordEntries() }
     LaunchedEffect(content) {
@@ -101,7 +102,7 @@ fun DetailScreen(id: Int, presenter: DetailPresenter? = null) {
       }
     }
     val translations = state.wordTranslations
-    val textStyle: TextStyle = MaterialTheme.typography.bodyLarge
+    val textStyle: TextStyle = MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp)
     val textMeasurer = rememberTextMeasurer()
     val measureTextWidth = remember(textMeasurer, textStyle) {
       { text: String ->
@@ -210,9 +211,9 @@ fun DetailScreen(id: Int, presenter: DetailPresenter? = null) {
       )
     }
     if (state.ipa != null) {
-      Text("IPA: ${state.ipa}", style = MaterialTheme.typography.bodySmall)
+      Text("IPA: ${state.ipa}", style = MaterialTheme.typography.bodyMedium)
     }
-    Text("Source: ${state.sourceUrl}", style = MaterialTheme.typography.bodySmall)
+    Text("Source: ${state.sourceUrl}", style = MaterialTheme.typography.bodyMedium)
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge the detail screen title and body text for better readability
- bump the IPA and source text to the medium body style to match the larger body copy

## Testing
- ./gradlew --console=plain :feature:detail:ui:test *(fails: Build-tool 35.0.0 has corrupt source.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68cec419f1948328939a061b2d514371