### PR TITLE
Add blur effect to catalog glass buttons

### DIFF
--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -108,7 +108,14 @@ fun CatalogScreen(
     }
   }
   val buttonGlassTint = Color(0xFF98A9CF)
-  val settingsGlassRect = remember(settingsButtonOffset, settingsButtonSize, density, buttonGlassTint) {
+  val buttonBlurRadius = 12.dp
+  val settingsGlassRect = remember(
+    settingsButtonOffset,
+    settingsButtonSize,
+    density,
+    buttonGlassTint,
+    buttonBlurRadius,
+  ) {
     val buttonOffset = settingsButtonOffset
     val buttonSize = settingsButtonSize
     if (buttonOffset == null || buttonSize == null) {
@@ -121,11 +128,18 @@ fun CatalogScreen(
           width = buttonSize.width.toDp(),
           height = buttonSize.height.toDp(),
           tintColor = buttonGlassTint,
+          blurRadius = buttonBlurRadius,
         )
       }
     }
   }
-  val refreshGlassRect = remember(refreshButtonOffset, refreshButtonSize, density, buttonGlassTint) {
+  val refreshGlassRect = remember(
+    refreshButtonOffset,
+    refreshButtonSize,
+    density,
+    buttonGlassTint,
+    buttonBlurRadius,
+  ) {
     val buttonOffset = refreshButtonOffset
     val buttonSize = refreshButtonSize
     if (buttonOffset == null || buttonSize == null) {
@@ -138,6 +152,7 @@ fun CatalogScreen(
           width = buttonSize.width.toDp(),
           height = buttonSize.height.toDp(),
           tintColor = buttonGlassTint,
+          blurRadius = buttonBlurRadius,
         )
       }
     }


### PR DESCRIPTION
## Summary
- allow liquid glass rects to request an additional blur radius in the runtime shader chain
- add a subtle blur to the catalog settings and refresh button overlays so they appear more frosted

## Testing
- ./gradlew --console=plain :core:designsystem:compileDebugKotlin :feature:catalog:ui:compileDebugKotlin *(fails: Android SDK Build-Tools 35 could not be installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec3eaa5048328ac21005cf7abe4d6