### PR TITLE
Add gwern-inspired decorations to catalog spacers

### DIFF
--- a/app/src/androidTest/java/com/archstarter/app/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/archstarter/app/MainActivityTest.kt
@@ -14,7 +14,7 @@ class MainActivityTest {
   val composeTestRule = createAndroidComposeRule<MainActivity>()
 
   @Test
-  fun catalogTitleIsDisplayed() {
-    composeTestRule.onNodeWithText("Catalog").assertIsDisplayed()
+  fun catalogSettingsButtonIsDisplayed() {
+    composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
   }
 }

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -2,6 +2,7 @@ package com.archstarter.feature.catalog.ui
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.snapping.SnapPosition
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.*
@@ -16,10 +17,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
@@ -34,6 +36,7 @@ import com.archstarter.feature.catalog.api.CatalogState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.math.abs
+import kotlin.math.min
 
 private const val TOP_SPACER_KEY = "catalog_top_spacer"
 private const val BOTTOM_SPACER_KEY = "catalog_bottom_spacer"
@@ -192,8 +195,6 @@ fun CatalogScreen(
           .fillMaxSize()
           .padding(horizontal = 16.dp, vertical = 16.dp)
       ) {
-        Text("Catalog", style = MaterialTheme.typography.titleLarge)
-        Spacer(Modifier.height(8.dp))
         Box(
           modifier = Modifier
             .weight(1f)
@@ -207,13 +208,19 @@ fun CatalogScreen(
             verticalArrangement = Arrangement.spacedBy(itemSpacing)
           ) {
             item(key = TOP_SPACER_KEY) {
-              Spacer(Modifier.height(edgeSpacerHeight))
+              GwernDecoratedSpacer(
+                height = edgeSpacerHeight,
+                isTop = true,
+              )
             }
             items(state.items, key = { it }) { id ->
               CatalogItemCard(id = id)
             }
             item(key = BOTTOM_SPACER_KEY) {
-              Spacer(Modifier.height(edgeSpacerHeight))
+              GwernDecoratedSpacer(
+                height = edgeSpacerHeight,
+                isTop = false,
+              )
             }
           }
         }
@@ -273,6 +280,100 @@ fun CatalogScreen(
         }
       }
     }
+  }
+}
+
+@Composable
+private fun GwernDecoratedSpacer(
+  height: Dp,
+  isTop: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  val coercedHeight = height.coerceAtLeast(0.dp)
+  if (coercedHeight <= 0.dp) {
+    Spacer(modifier.height(coercedHeight))
+    return
+  }
+
+  val density = LocalDensity.current
+  val accentColor = Color(0xFFAD8A4A)
+  val backgroundTop = Color(0xFFF7F5EF)
+  val backgroundBottom = Color(0xFFF0EFEA)
+  val borderColor = Color(0xFF9C9C9C)
+  val stripeColor = accentColor.copy(alpha = 0.18f)
+
+  Canvas(
+    modifier
+      .fillMaxWidth()
+      .height(coercedHeight)
+  ) {
+    val widthPx = size.width
+    val heightPx = size.height
+    val backgroundBrush = if (isTop) {
+      Brush.verticalGradient(listOf(backgroundBottom, backgroundTop))
+    } else {
+      Brush.verticalGradient(listOf(backgroundTop, backgroundBottom))
+    }
+    drawRect(brush = backgroundBrush)
+
+    val stripeSpacing = with(density) { 22.dp.toPx() }
+    val stripeStrokeWidth = with(density) { 0.75.dp.toPx() }
+    if (stripeSpacing > 0f && stripeStrokeWidth > 0f) {
+      var startX = -heightPx
+      while (startX < widthPx + heightPx) {
+        val startY = if (isTop) heightPx else 0f
+        val endY = if (isTop) 0f else heightPx
+        drawLine(
+          color = stripeColor,
+          start = Offset(startX, startY),
+          end = Offset(startX + heightPx, endY),
+          strokeWidth = stripeStrokeWidth,
+        )
+        startX += stripeSpacing
+      }
+    }
+
+    val accentStrokeWidth = with(density) { 1.25.dp.toPx() }
+    val accentMargin = min(heightPx / 3f, with(density) { 12.dp.toPx() })
+    val accentY = if (isTop) heightPx - accentMargin else accentMargin
+    drawLine(
+      color = accentColor,
+      start = Offset(0f, accentY),
+      end = Offset(widthPx, accentY),
+      strokeWidth = accentStrokeWidth,
+    )
+
+    val dotRadius = min(with(density) { 2.5.dp.toPx() }, accentMargin / 1.8f)
+    val dotSpacing = with(density) { 20.dp.toPx() }
+    if (dotSpacing > 0f && dotRadius > 0f) {
+      var x = dotSpacing / 2f
+      while (x < widthPx) {
+        drawCircle(
+          color = accentColor.copy(alpha = 0.85f),
+          radius = dotRadius,
+          center = Offset(x, accentY),
+        )
+        drawCircle(
+          color = Color(0xFFF9F7F1),
+          radius = dotRadius * 0.45f,
+          center = Offset(x, accentY),
+        )
+        x += dotSpacing
+      }
+    }
+
+    val borderStrokeWidth = with(density) { 1.dp.toPx() }
+    val borderY = if (isTop) {
+      heightPx - borderStrokeWidth / 2f
+    } else {
+      borderStrokeWidth / 2f
+    }
+    drawLine(
+      color = borderColor,
+      start = Offset(0f, borderY),
+      end = Offset(widthPx, borderY),
+      strokeWidth = borderStrokeWidth,
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the Catalog title header from the catalog screen layout
- render gwern.net-inspired canvas decorations in the top and bottom LazyColumn spacers
- update the instrumentation test to look for the Settings button instead of the removed title

## Testing
- ./gradlew --console=plain :feature:catalog:ui:compileDebugKotlin :app:compileDebugAndroidTestKotlin *(fails: Android SDK Build-Tools 35 installation error in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cef053a33c8328975c354a9c08f552