### PR TITLE
Scroll to newly added catalog item

### DIFF
--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -45,6 +45,17 @@ fun CatalogScreen(
   val p = presenter ?: rememberPresenter<CatalogPresenter, Unit>()
   val state by p.state.collectAsStateWithLifecycle()
   val listState = rememberLazyListState()
+  var previousItems by remember { mutableStateOf<List<Int>>(emptyList()) }
+  LaunchedEffect(state.items) {
+    val newId = state.items.firstOrNull { id -> !previousItems.contains(id) }
+    previousItems = state.items
+    if (newId != null) {
+      val index = state.items.indexOf(newId)
+      if (index >= 0) {
+        listState.animateScrollToItem(index + 1) // +1 for the top spacer item
+      }
+    }
+  }
   val flingBehavior = rememberSnapFlingBehavior(
     lazyListState = listState,
     snapPosition = SnapPosition.Center


### PR DESCRIPTION
## Summary
- animate the catalog list to scroll new article IDs into view
- offset the scroll target to account for the leading spacer in the lazy list

## Testing
- ./gradlew :feature:catalog:ui:lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf9ac205848328b51548f9bd2dff54