### PR TITLE
Remove catalog top toolbar

### DIFF
--- a/app/src/androidTest/java/com/archstarter/app/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/archstarter/app/MainActivityTest.kt
@@ -14,7 +14,7 @@ class MainActivityTest {
   val composeTestRule = createAndroidComposeRule<MainActivity>()
 
   @Test
-  fun catalogTitleIsDisplayed() {
-    composeTestRule.onNodeWithText("Catalog").assertIsDisplayed()
+  fun settingsButtonIsDisplayed() {
+    composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
   }
 }

--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -192,8 +192,6 @@ fun CatalogScreen(
           .fillMaxSize()
           .padding(horizontal = 16.dp, vertical = 16.dp)
       ) {
-        Text("Catalog", style = MaterialTheme.typography.titleLarge)
-        Spacer(Modifier.height(8.dp))
         Box(
           modifier = Modifier
             .weight(1f)


### PR DESCRIPTION
## Summary
- remove the catalog screen header to eliminate the top toolbar
- update the instrumentation test to look for the Settings action instead of the removed title

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf9b34c80c8328bfe5f34efbfca839