### PR TITLE
Guard highlight layout bounds against stale indices

### DIFF
--- a/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
+++ b/feature/detail/ui/src/main/java/com/archstarter/feature/detail/ui/DetailScreen.kt
@@ -564,8 +564,11 @@ private fun TextLayoutResult.toLiquidRect(
   paddingY: Float
 ): LiquidRectPx? {
   if (range == null || range.length <= 0) return null
+  val layoutTextLength = layoutInput.text.length
+  if (layoutTextLength <= 0) return null
   val start = range.start.coerceAtLeast(0)
-  val end = range.end
+  if (start >= layoutTextLength) return null
+  val end = min(range.end, layoutTextLength)
   if (end <= start) return null
   val lastIndex = end - 1
   val startBox = getBoundingBox(start)


### PR DESCRIPTION
## Summary
- guard LiquidRect calculation against stale text layout indices to avoid IllegalArgumentException

## Testing
- ./gradlew :feature:detail:ui:test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d2e5c9ccdc83289595208a67880e86