### PR TITLE
Show loader while initial catalog refresh is running

### DIFF
--- a/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
+++ b/feature/catalog/ui/src/main/java/com/archstarter/feature/catalog/ui/CatalogScreen.kt
@@ -240,6 +240,15 @@ fun CatalogScreen(
               )
             }
           }
+
+          if (state.items.isEmpty() && state.isRefreshing) {
+            Box(
+              modifier = Modifier.fillMaxSize(),
+              contentAlignment = Alignment.Center,
+            ) {
+              CircularProgressIndicator()
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- overlay a centered progress indicator while the catalog is refreshing and contains no items

## Testing
- ./gradlew :feature:catalog:impl:test --console=plain *(fails: Android build tools 35.0.0 missing core-lambda-stubs.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68d42b427d1c832894e62e966b131116