### PR TITLE
Create liquid glass themed top bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:label="Infislate">
+        android:label="Infislate"
+        android:theme="@style/Theme.Infislate">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/archstarter/app/AppTopBar.kt
+++ b/app/src/main/java/com/archstarter/app/AppTopBar.kt
@@ -1,0 +1,254 @@
+package com.archstarter.app
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.archstarter.core.designsystem.LiquidGlassRect
+import com.archstarter.core.designsystem.LiquidGlassRectOverlay
+import com.archstarter.core.designsystem.LiquidGlassSpec
+
+@Composable
+fun AppTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String = "Liquid learning",
+) {
+    val density = LocalDensity.current
+    var barOffset by remember { mutableStateOf(Offset.Zero) }
+    var barSize by remember { mutableStateOf(IntSize.Zero) }
+    var accentOffset by remember { mutableStateOf(Offset.Zero) }
+    var accentSize by remember { mutableStateOf(IntSize.Zero) }
+    var beamOffset by remember { mutableStateOf(Offset.Zero) }
+    var beamSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val barRect = remember(barOffset, barSize, density) {
+        if (barSize.width == 0 || barSize.height == 0) {
+            null
+        } else {
+            with(density) {
+                LiquidGlassRect(
+                    left = barOffset.x.toDp(),
+                    top = barOffset.y.toDp(),
+                    width = barSize.width.toDp(),
+                    height = barSize.height.toDp(),
+                    tintColor = Color(0x3323417A)
+                )
+            }
+        }
+    }
+    val accentRect = remember(accentOffset, accentSize, density) {
+        if (accentSize.width == 0 || accentSize.height == 0) {
+            null
+        } else {
+            with(density) {
+                LiquidGlassRect(
+                    left = accentOffset.x.toDp(),
+                    top = accentOffset.y.toDp(),
+                    width = accentSize.width.toDp(),
+                    height = accentSize.height.toDp(),
+                    tintColor = Color(0x66F9F871)
+                )
+            }
+        }
+    }
+    val beamRect = remember(beamOffset, beamSize, density) {
+        if (beamSize.width == 0 || beamSize.height == 0) {
+            null
+        } else {
+            with(density) {
+                LiquidGlassRect(
+                    left = beamOffset.x.toDp(),
+                    top = beamOffset.y.toDp(),
+                    width = beamSize.width.toDp(),
+                    height = beamSize.height.toDp(),
+                    tintColor = Color(0x6630E5FF)
+                )
+            }
+        }
+    }
+    val glassRects = remember(barRect, accentRect, beamRect) {
+        listOfNotNull(barRect, accentRect, beamRect)
+    }
+
+    LiquidGlassRectOverlay(
+        rects = glassRects,
+        spec = LiquidGlassSpec(
+            cornerRadius = 40.dp,
+            bezelWidth = 20.dp,
+            displacementScalePx = 54f,
+            highlight = 0.72f,
+            tiltPitch = 0.12f,
+        ),
+        modifier = modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 96.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .height(84.dp)
+                    .shadow(18.dp, RoundedCornerShape(40.dp))
+                    .clip(RoundedCornerShape(40.dp))
+                    .background(
+                        brush = Brush.linearGradient(
+                            colors = listOf(
+                                Color(0xFF1F2A8C),
+                                Color(0xFF4C4FF0),
+                                Color(0xFF00B4D8),
+                            ),
+                            start = Offset(0f, 0f),
+                            end = Offset(820f, 520f),
+                        )
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = Color.White.copy(alpha = 0.18f),
+                        shape = RoundedCornerShape(40.dp)
+                    )
+                    .onGloballyPositioned { coords ->
+                        barOffset = coords.positionInRoot()
+                        barSize = coords.size
+                    }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 10.dp, end = 16.dp)
+                        .size(96.dp)
+                        .clip(RoundedCornerShape(48.dp))
+                        .background(Color.White.copy(alpha = 0.08f))
+                        .onGloballyPositioned { coords ->
+                            accentOffset = coords.positionInRoot()
+                            accentSize = coords.size
+                        }
+                )
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(start = 20.dp, bottom = 16.dp)
+                        .size(width = 132.dp, height = 38.dp)
+                        .clip(RoundedCornerShape(19.dp))
+                        .background(Color.White.copy(alpha = 0.08f))
+                        .onGloballyPositioned { coords ->
+                            beamOffset = coords.positionInRoot()
+                            beamSize = coords.size
+                        }
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(52.dp)
+                                .clip(RoundedCornerShape(20.dp))
+                                .background(Color.White.copy(alpha = 0.12f))
+                                .border(
+                                    width = 1.dp,
+                                    color = Color.White.copy(alpha = 0.24f),
+                                    shape = RoundedCornerShape(20.dp)
+                                )
+                                .padding(8.dp)
+                        ) {
+                            Image(
+                                painter = painterResource(R.drawable.app_icon),
+                                contentDescription = null,
+                                modifier = Modifier.fillMaxWidth(),
+                                contentScale = ContentScale.Crop
+                            )
+                        }
+                        Spacer(Modifier.size(16.dp))
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(
+                                    SpanStyle(
+                                        brush = Brush.linearGradient(
+                                            colors = listOf(
+                                                Color(0xFFF9F871),
+                                                Color(0xFFF3722C),
+                                                Color(0xFFFF2D75),
+                                            )
+                                        ),
+                                        shadow = Shadow(
+                                            color = Color.Black.copy(alpha = 0.35f),
+                                            offset = Offset(0f, 3f),
+                                            blurRadius = 8f,
+                                        )
+                                    )
+                                ) {
+                                    append(title)
+                                }
+                            },
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                color = Color.White
+                            )
+                        )
+                    }
+                    if (subtitle.isNotEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(20.dp))
+                                .background(Color.White.copy(alpha = 0.16f))
+                                .padding(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.labelLarge.copy(
+                                    color = Color.White.copy(alpha = 0.92f)
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/archstarter/app/Nav.kt
+++ b/app/src/main/java/com/archstarter/app/Nav.kt
@@ -1,13 +1,13 @@
 package com.archstarter.app
 
+import android.graphics.Color
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -21,6 +21,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import androidx.core.view.WindowCompat
 import com.archstarter.core.common.app.App
 import com.archstarter.core.common.presenter.LocalPresenterResolver
 import com.archstarter.core.common.scope.LocalScreenBuilder
@@ -56,6 +57,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: android.os.Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
         setContent {
             AppTheme {
                 val nav = rememberNavController()
@@ -75,26 +79,28 @@ class MainActivity : ComponentActivity() {
                     if (startDestinationState.value == null && onboardingCompleted != null) {
                         startDestinationState.value = if (onboardingCompleted == true) Catalog else Onboarding
                     }
-                    Box(
-                        modifier = Modifier
-                            .imePadding()
-                            .navigationBarsPadding()
-                            .systemBarsPadding()
-                            .safeContentPadding()
-                            .fillMaxSize()
-                    ) {
-                        val startDestination = startDestinationState.value
-                        if (startDestination != null) {
-                            AppNavHost(
-                                nav = nav,
-                                startDestination = startDestination,
-                                onOnboardingFinished = {
-                                    nav.navigate(Catalog) {
-                                        popUpTo(Onboarding) { inclusive = true }
-                                        launchSingleTop = true
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        AppTopBar(title = "Infislate")
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxSize()
+                                .imePadding()
+                                .navigationBarsPadding()
+                        ) {
+                            val startDestination = startDestinationState.value
+                            if (startDestination != null) {
+                                AppNavHost(
+                                    nav = nav,
+                                    startDestination = startDestination,
+                                    onOnboardingFinished = {
+                                        nav.navigate(Catalog) {
+                                            popUpTo(Onboarding) { inclusive = true }
+                                            launchSingleTop = true
+                                        }
                                     }
-                                }
-                            )
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Infislate" parent="@android:style/Theme.Material.NoActionBar">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">false</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- remove the default action bar theme and expose transparent system bars for a custom toolbar
- add a liquid-glass inspired AppTopBar composable and show it above the navigation host
- configure MainActivity for edge-to-edge drawing so the new toolbar renders beneath the system bars

## Testing
- ./gradlew :app:assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d42ad1c9948328bc35def621aebeb5