### PR TITLE
Refactor liquid glass tilt sensor handling

### DIFF
--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
   implementation(libs.compose.material3)
   implementation(libs.compose.preview)
   debugImplementation(libs.compose.tooling)
+  testImplementation(libs.junit)
 }

--- a/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlassTilt.kt
+++ b/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlassTilt.kt
@@ -50,8 +50,8 @@ internal fun rememberLiquidGlassTilt(enabled: Boolean): LiquidGlassTilt {
             override fun onSensorChanged(event: SensorEvent) {
                 SensorManager.getRotationMatrixFromVector(rotationMatrix, event.values)
                 SensorManager.getOrientation(rotationMatrix, orientationAngles)
-                val rawPitch = orientationAngles[1]
-                val rawRoll = orientationAngles[2]
+                val rawPitch = orientationAngles[0]
+                val rawRoll = orientationAngles[1]
                 tiltProcessor.update(rawRoll, rawPitch)?.let { newTilt ->
                     tilt = newTilt
                 }

--- a/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlassTiltProcessor.kt
+++ b/core/designsystem/src/main/java/com/archstarter/core/designsystem/LiquidGlassTiltProcessor.kt
@@ -1,0 +1,82 @@
+package com.archstarter.core.designsystem
+
+import kotlin.math.PI
+import kotlin.math.abs
+
+internal object LiquidGlassTiltConfig {
+    const val FILTER_ALPHA = 0.12f
+    const val ANGLE_EPSILON = 0.0005f
+    const val PITCH_EPSILON = 0.0005f
+    const val MAX_SHADER_ROTATION = 0.45f
+    val HALF_PI = (PI / 2.0).toFloat()
+    val MAX_ROLL = HALF_PI * 0.9f
+    val MAX_PITCH = HALF_PI * 0.75f
+}
+
+internal class LiquidGlassTiltProcessor(
+    private val config: Config = Config(),
+) {
+
+    data class Config(
+        val filterAlpha: Float = LiquidGlassTiltConfig.FILTER_ALPHA,
+        val angleEpsilon: Float = LiquidGlassTiltConfig.ANGLE_EPSILON,
+        val pitchEpsilon: Float = LiquidGlassTiltConfig.PITCH_EPSILON,
+        val maxShaderRotation: Float = LiquidGlassTiltConfig.MAX_SHADER_ROTATION,
+        val maxRoll: Float = LiquidGlassTiltConfig.MAX_ROLL,
+        val maxPitch: Float = LiquidGlassTiltConfig.MAX_PITCH,
+        val rollMultiplier: Float = -1f,
+        val pitchMultiplier: Float = -1f,
+    )
+
+    private var filteredAngle = LiquidGlassTilt.Zero.angle
+    private var filteredPitch = LiquidGlassTilt.Zero.pitch
+    private var lastDispatchedAngle = LiquidGlassTilt.Zero.angle
+    private var lastDispatchedPitch = LiquidGlassTilt.Zero.pitch
+
+    fun reset(initialTilt: LiquidGlassTilt = LiquidGlassTilt.Zero) {
+        filteredAngle = initialTilt.angle
+        filteredPitch = initialTilt.pitch
+        lastDispatchedAngle = initialTilt.angle
+        lastDispatchedPitch = initialTilt.pitch
+    }
+
+    fun update(rawRoll: Float, rawPitch: Float): LiquidGlassTilt? {
+        val sanitizedRoll = rawRoll.coerceFinite()
+        val sanitizedPitch = rawPitch.coerceFinite()
+        val targetAngle = mapRoll(sanitizedRoll)
+        val targetPitch = mapPitch(sanitizedPitch)
+        filteredAngle += (targetAngle - filteredAngle) * config.filterAlpha
+        filteredPitch += (targetPitch - filteredPitch) * config.filterAlpha
+        if (shouldDispatch()) {
+            val newTilt = LiquidGlassTilt(filteredAngle, filteredPitch)
+            lastDispatchedAngle = newTilt.angle
+            lastDispatchedPitch = newTilt.pitch
+            return newTilt
+        }
+        return null
+    }
+
+    private fun shouldDispatch(): Boolean {
+        return abs(filteredAngle - lastDispatchedAngle) > config.angleEpsilon ||
+            abs(filteredPitch - lastDispatchedPitch) > config.pitchEpsilon
+    }
+
+    private fun mapRoll(rawRoll: Float): Float {
+        if (config.maxRoll <= 0f) return 0f
+        val clamped = rawRoll.coerceIn(-config.maxRoll, config.maxRoll)
+        val normalized = clamped / config.maxRoll
+        val scaled = normalized * config.rollMultiplier
+        return scaled * config.maxShaderRotation
+    }
+
+    private fun mapPitch(rawPitch: Float): Float {
+        if (config.maxPitch <= 0f) return 0f
+        val clamped = rawPitch.coerceIn(-config.maxPitch, config.maxPitch)
+        val normalized = clamped / config.maxPitch
+        val scaled = normalized * config.pitchMultiplier
+        return scaled.coerceIn(-1f, 1f)
+    }
+}
+
+private fun Float.coerceFinite(): Float =
+    if (isNaN() || isInfinite()) 0f else this

--- a/core/designsystem/src/test/java/com/archstarter/core/designsystem/LiquidGlassTiltProcessorTest.kt
+++ b/core/designsystem/src/test/java/com/archstarter/core/designsystem/LiquidGlassTiltProcessorTest.kt
@@ -1,0 +1,126 @@
+package com.archstarter.core.designsystem
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LiquidGlassTiltProcessorTest {
+
+    private fun createProcessor(config: LiquidGlassTiltProcessor.Config = LiquidGlassTiltProcessor.Config(
+        filterAlpha = 1f,
+        angleEpsilon = 0f,
+        pitchEpsilon = 0f,
+        maxShaderRotation = 1f,
+        maxRoll = 1f,
+        maxPitch = 1f,
+        rollMultiplier = -1f,
+        pitchMultiplier = -1f,
+    )): LiquidGlassTiltProcessor = LiquidGlassTiltProcessor(config)
+
+    @Test
+    fun `positive roll tilts glass in the same direction as device`() {
+        val processor = createProcessor()
+
+        val result = processor.update(rawRoll = 1f, rawPitch = 0f)
+
+        requireNotNull(result)
+        assertEquals(-1f, result.angle, 0.0001f)
+        assertEquals(0f, result.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `positive pitch decreases highlight intensity`() {
+        val processor = createProcessor()
+
+        val result = processor.update(rawRoll = 0f, rawPitch = 1f)
+
+        requireNotNull(result)
+        assertEquals(0f, result.angle, 0.0001f)
+        assertEquals(-1f, result.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `values are clamped to configured bounds`() {
+        val processor = createProcessor()
+
+        val result = processor.update(rawRoll = 5f, rawPitch = -5f)
+
+        requireNotNull(result)
+        assertEquals(-1f, result.angle, 0.0001f)
+        assertEquals(1f, result.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `low pass filter smooths the signal`() {
+        val processor = LiquidGlassTiltProcessor(
+            LiquidGlassTiltProcessor.Config(
+                filterAlpha = 0.5f,
+                angleEpsilon = 0f,
+                pitchEpsilon = 0f,
+                maxShaderRotation = 1f,
+                maxRoll = 1f,
+                maxPitch = 1f,
+                rollMultiplier = -1f,
+                pitchMultiplier = -1f,
+            ),
+        )
+
+        val result = processor.update(rawRoll = 1f, rawPitch = 0f)
+
+        requireNotNull(result)
+        assertEquals(-0.5f, result.angle, 0.0001f)
+        assertEquals(0f, result.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `epsilon thresholds prevent insignificant updates`() {
+        val processor = LiquidGlassTiltProcessor(
+            LiquidGlassTiltProcessor.Config(
+                filterAlpha = 1f,
+                angleEpsilon = 0.2f,
+                pitchEpsilon = 0.2f,
+                maxShaderRotation = 1f,
+                maxRoll = 1f,
+                maxPitch = 1f,
+                rollMultiplier = -1f,
+                pitchMultiplier = -1f,
+            ),
+        )
+
+        val smallChange = processor.update(rawRoll = 0.1f, rawPitch = 0.1f)
+        assertNull(smallChange)
+
+        val largeChange = processor.update(rawRoll = 1f, rawPitch = 1f)
+        requireNotNull(largeChange)
+        assertEquals(-1f, largeChange.angle, 0.0001f)
+        assertEquals(-1f, largeChange.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `reset uses provided tilt as the new baseline`() {
+        val processor = createProcessor()
+
+        processor.update(rawRoll = 1f, rawPitch = 1f)
+        processor.reset(LiquidGlassTilt(angle = 0.25f, pitch = -0.5f))
+
+        val result = processor.update(rawRoll = 1f, rawPitch = 1f)
+
+        requireNotNull(result)
+        assertEquals(-1f, result.angle, 0.0001f)
+        assertEquals(-1f, result.pitch, 0.0001f)
+    }
+
+    @Test
+    fun `non finite sensor readings are ignored`() {
+        val processor = createProcessor()
+
+        val result = processor.update(rawRoll = Float.NaN, rawPitch = Float.POSITIVE_INFINITY)
+
+        assertNull(result)
+
+        val next = processor.update(rawRoll = 1f, rawPitch = 0f)
+        requireNotNull(next)
+        assertEquals(-1f, next.angle, 0.0001f)
+        assertEquals(0f, next.pitch, 0.0001f)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the in-place tilt calculations with a dedicated `LiquidGlassTiltProcessor` that normalizes, filters, and flips roll/pitch to match the visual direction
- update `rememberLiquidGlassTilt` to use the processor inside a `DisposableEffect`, simplifying sensor registration and cleanup
- add unit coverage for the processor and pull in JUnit so the tests run during CI

## Testing
- ./gradlew :core:designsystem:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d42b17532483289c68625383c28a53