### PR TITLE
Fix language dropdown scroll position

### DIFF
--- a/feature/settings/ui/src/main/java/com/archstarter/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/ui/src/main/java/com/archstarter/feature/settings/ui/SettingsScreen.kt
@@ -121,9 +121,11 @@ private fun LanguageChooserContent(
     val listState = rememberLazyListState()
     var anchorBounds by remember { mutableStateOf<IntRect?>(null) }
 
-    LaunchedEffect(state.isExpanded, state.query) {
+    LaunchedEffect(state.isExpanded, state.results, state.selectedLanguage) {
         if (state.isExpanded) {
-            listState.scrollToItem(0)
+            val selectedIndex = state.results.indexOf(state.selectedLanguage)
+            val targetIndex = if (selectedIndex >= 0) selectedIndex else 0
+            listState.scrollToItem(targetIndex)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the language dropdown scrolls to the currently selected item when opened

## Testing
- ./gradlew :feature:settings:ui:compileDebugKotlin --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d42d955d908328b133960910fd2ce7