### PR TITLE
Lifecycle-aware ScreenScope: fix stale subscriptions & VM reuse

### DIFF
--- a/app/src/main/java/com/archstarter/app/Nav.kt
+++ b/app/src/main/java/com/archstarter/app/Nav.kt
@@ -23,6 +23,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.archstarter.core.common.app.App
 import com.archstarter.core.common.presenter.LocalPresenterResolver
+import com.archstarter.core.common.scope.LocalAppInstanceId
 import com.archstarter.core.common.scope.LocalScreenBuilder
 import com.archstarter.core.common.scope.ScreenComponent
 import com.archstarter.core.common.scope.ScreenScope
@@ -68,7 +69,10 @@ class MainActivity : ComponentActivity() {
                 }
                 CompositionLocalProvider(
                     LocalPresenterResolver provides resolver,
-                    LocalScreenBuilder provides screenBuilder
+                    LocalScreenBuilder provides screenBuilder,
+                    // Identity of the current App changes when the activity is recreated, which
+                    // triggers a rebuild of screen components (fixes the font-scale ANR/staleness).
+                    LocalAppInstanceId provides System.identityHashCode(app)
                 ) {
                     val onboardingCompleted by onboardingStatus.hasCompleted.collectAsStateWithLifecycle(initialValue = null)
                     val startDestinationState = remember { mutableStateOf<Any?>(null) }

--- a/core/common/src/main/kotlin/com/archstarter/core/common/presenter/Presenter.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/presenter/Presenter.kt
@@ -1,14 +1,19 @@
 package com.archstarter.core.common.presenter
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.compose.LifecycleStartEffect
 import com.archstarter.core.common.BuildConfig
 import kotlin.reflect.KClass
 
 interface ParamInit<P> {
   fun initOnce(params: P?)
+}
+
+/** Implement in a presenter to be notified when its screen leaves the foreground (ON_STOP). */
+interface LifecycleStop {
+  fun onStop()
 }
 
 interface PresenterResolver {
@@ -31,8 +36,14 @@ inline fun <reified P : ParamInit<Params>, Params> rememberPresenter(
     ?: presenterMock(P::class, key)
     ?: error("No presenter for ${P::class.simpleName} with key=$key")
 
-  LaunchedEffect(presenter, params) {
+  // LifecycleStartEffect (not LaunchedEffect) so initOnce re-runs each time the screen returns to
+  // the foreground and LifecycleStop.onStop fires when it leaves — keeps presenter subscriptions in
+  // step with visibility instead of running once and leaking while off-screen.
+  LifecycleStartEffect(presenter, params) {
     (presenter as? ParamInit<Params>)?.initOnce(params)
+    onStopOrDispose {
+      (presenter as? LifecycleStop)?.onStop()
+    }
   }
   return presenter
 }

--- a/core/common/src/main/kotlin/com/archstarter/core/common/scope/EntryPoints.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/scope/EntryPoints.kt
@@ -29,3 +29,9 @@ interface VmMapEntryPoint {
 interface SubVmMapEntryPoint {
   fun vmFactories(): Map<Class<out ViewModel>, @JvmSuppressWildcards AssistedVmFactory<out ViewModel>>
 }
+
+@EntryPoint
+@InstallIn(ScreenComponent::class)
+interface ScreenScopeHolderEntryPoint {
+  fun screenScopeHolder(): ScreenScopeHolder
+}

--- a/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenComponentHolder.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenComponentHolder.kt
@@ -1,0 +1,81 @@
+package com.archstarter.core.common.scope
+
+import android.util.Log
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import dagger.hilt.EntryPoints
+
+/**
+ * A [ViewModel] that owns the [ScreenComponent] instance so its lifetime matches the hosting
+ * ViewModelStore (i.e. the NavBackStackEntry):
+ * - survives recompositions and configuration changes,
+ * - is only disposed when the entry leaves the back stack,
+ * - is rebuilt when the owning activity/App instance changes (e.g. font-scale recreation), so
+ *   Hilt-provided singletons captured by the old graph don't go stale.
+ */
+class ScreenComponentHolder(
+  private val builder: ScreenComponent.Builder,
+  private var appInstanceId: Int,
+) : ViewModel() {
+
+  var component: ScreenComponent by mutableStateOf(builder.build())
+    private set
+
+  init {
+    log("created component inst=${System.identityHashCode(component)}, appInstanceId=$appInstanceId")
+  }
+
+  /** Attach the [LifecycleOwner]'s lifecycle so screen-scoped coroutines pause/resume with it. */
+  fun attachLifecycle(lifecycleOwner: LifecycleOwner) {
+    try {
+      scopeHolder(component).attachLifecycle(lifecycleOwner.lifecycle)
+      log("attached lifecycle from $lifecycleOwner")
+    } catch (e: Exception) {
+      log("error attaching lifecycle: ${e.message}")
+    }
+  }
+
+  /** Rebuild the component when the App/activity instance changes, cancelling the old graph. */
+  fun updateAppInstance(newAppInstanceId: Int) {
+    if (appInstanceId == newAppInstanceId) return
+
+    val oldComponent = component
+    val oldInst = System.identityHashCode(oldComponent)
+    cancelComponent(oldComponent, "app instance changed from $appInstanceId to $newAppInstanceId")
+
+    component = builder.build()
+    appInstanceId = newAppInstanceId
+    log("rebuilt component oldInst=$oldInst, newInst=${System.identityHashCode(component)}, appInstanceId=$appInstanceId")
+  }
+
+  override fun onCleared() {
+    log("onCleared() - cancelling component inst=${System.identityHashCode(component)}")
+    cancelComponent(component, "holder cleared")
+    super.onCleared()
+  }
+
+  private fun cancelComponent(component: ScreenComponent, reason: String) {
+    try {
+      scopeHolder(component).cancel()
+      log("cancelled component inst=${System.identityHashCode(component)} because $reason")
+    } catch (e: Exception) {
+      log("error cancelling scopeHolder: ${e.message}")
+    }
+  }
+
+  private fun scopeHolder(component: ScreenComponent): ScreenScopeHolder =
+    EntryPoints.get(component, ScreenScopeHolderEntryPoint::class.java).screenScopeHolder()
+
+  private fun log(msg: String) = Log.d("ScreenComponentHolder", msg)
+
+  companion object {
+    fun factory(builder: ScreenComponent.Builder, appInstanceId: Int) = viewModelFactory {
+      initializer { ScreenComponentHolder(builder, appInstanceId) }
+    }
+  }
+}

--- a/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenCoroutineScope.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenCoroutineScope.kt
@@ -1,0 +1,87 @@
+package com.archstarter.core.common.scope
+
+import android.util.Log
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Inject
+
+/**
+ * Lifecycle-aware coroutine scope owned by a [ScreenComponent].
+ *
+ * The scope backing [screenScope] behaves like this:
+ * - If a [Lifecycle] is attached: it pauses (cancels every child job) when the screen goes
+ *   off-screen (ON_STOP) and resumes (recreates the backing job) when it comes back (ON_START).
+ * - If no lifecycle is attached: it lives for as long as the component does and is only cancelled
+ *   when the component is disposed (see [cancel]).
+ *
+ * This is what lets flows collected in `viewModelScope` (via [ScreenViewModel]) stop collecting
+ * while the screen is not visible, instead of leaking a stale subscription that keeps firing.
+ */
+@ScreenScope
+class ScreenScopeHolder @Inject constructor() {
+  private val id = System.identityHashCode(this)
+
+  // Backing job that all coroutines launched from screenScope() are children of.
+  @Volatile
+  private var componentJob: Job? = null
+
+  @Volatile
+  private var lifecycle: Lifecycle? = null
+
+  private val lifecycleObserver = LifecycleEventObserver { _, event ->
+    when (event) {
+      Lifecycle.Event.ON_STOP -> {
+        log("ON_STOP - cancelling lifecycle-aware scope")
+        componentJob?.cancel()
+        componentJob = null
+      }
+      Lifecycle.Event.ON_START -> {
+        if (componentJob?.isActive != true) {
+          log("ON_START - recreating lifecycle-aware scope")
+          componentJob = SupervisorJob()
+        }
+      }
+      else -> {}
+    }
+  }
+
+  @Synchronized
+  private fun getJob(): Job {
+    if (componentJob?.isActive != true) {
+      componentJob = SupervisorJob()
+    }
+    return componentJob!!
+  }
+
+  /**
+   * A [CoroutineScope] tied to the current backing job. Coroutines launched from it are cancelled
+   * when the screen stops (if a lifecycle is attached) or when the component is disposed.
+   */
+  fun screenScope(): CoroutineScope = CoroutineScope(getJob() + Dispatchers.Main.immediate)
+
+  /** Attach a [Lifecycle] to enable automatic pause/resume of coroutines. Idempotent. */
+  fun attachLifecycle(lifecycle: Lifecycle) {
+    if (this.lifecycle == lifecycle) return
+    this.lifecycle?.removeObserver(lifecycleObserver)
+    this.lifecycle = lifecycle
+    log("lifecycle attached, state=${lifecycle.currentState}")
+    lifecycle.addObserver(lifecycleObserver)
+  }
+
+  /** Cancel the component-level scope. Called when the owning [ScreenComponent] is disposed. */
+  fun cancel() {
+    log("cancelled - all scopes will be cancelled")
+    lifecycle?.removeObserver(lifecycleObserver)
+    lifecycle = null
+    componentJob?.cancel()
+    componentJob = null
+  }
+
+  fun isActive(): Boolean = componentJob?.isActive == true
+
+  private fun log(msg: String) = Log.d("ScreenScopeHolder-$id", msg)
+}

--- a/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenScopeComposable.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenScopeComposable.kt
@@ -1,15 +1,26 @@
 package com.archstarter.core.common.scope
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
 import dagger.hilt.EntryPoints
 
-private val LocalScreenComponent = staticCompositionLocalOf<Any?> {
+private val LocalScreenComponent = compositionLocalOf<Any?> {
   null // Allow null default instead of error
 }
+
+/**
+ * Identifies the current App/activity instance. When it changes (e.g. the activity is recreated on
+ * a font-scale change) the top-level [ScreenComponent] is rebuilt so stale Hilt graphs are dropped.
+ * Provided by MainActivity.
+ */
+val LocalAppInstanceId = compositionLocalOf { 0 }
 
 // This will be provided by MainActivity
 val LocalScreenBuilder = staticCompositionLocalOf<ScreenComponent.Builder> {
@@ -22,31 +33,52 @@ fun ScreenScope(
   content: @Composable () -> Unit
 ) {
   val screenBuilder = LocalScreenBuilder.current
+  val appInstanceId = LocalAppInstanceId.current
+  val viewModelStoreOwner = LocalViewModelStoreOwner.current
+  val lifecycleOwner = LocalLifecycleOwner.current
 
   // Find nearest component (if any)
   val parentAny = LocalScreenComponent.current
 
-  // Decide which component to provide to children
-  val provided: Any = remember(parentAny, nested) {
-    when {
-      parentAny == null -> screenBuilder.build() // top-level screen component
-      nested -> {
-        // build a Subscreen from the nearest ScreenComponent
-        val parentScreen: ScreenComponent = when (parentAny) {
-          is ScreenComponent -> parentAny
-          is SubscreenComponent -> error("Cannot nest inside another SubscreenComponent")
-          else -> error("Unsupported parent type")
-        }
-        val subBuilder = EntryPoints.get(parentScreen, SubscreenBuilderEntryPoint::class.java).subBuilder()
-        subBuilder.build()
-      }
-      else -> parentAny // reuse nearest component if not nesting
-    }
-  }
+  // Decide which component to provide to children.
+  val provided: Any = when {
+    parentAny == null -> {
+      // Top-level screen component: store it in a ViewModel so its lifetime matches the
+      // ViewModelStore (NavBackStackEntry). This survives recompositions and config changes and
+      // is only disposed when the entry leaves the back stack.
+      if (viewModelStoreOwner != null) {
+        val holder: ScreenComponentHolder = viewModel(
+          viewModelStoreOwner = viewModelStoreOwner,
+          factory = ScreenComponentHolder.factory(screenBuilder, appInstanceId)
+        )
 
-  DisposableEffect(provided) {
-    onDispose {
-      // if you introduce Closeable deps, call close() here by EntryPoint
+        // Attach lifecycle ONLY for top-level components; nested subscreens share the parent scope.
+        LaunchedEffect(holder, lifecycleOwner, appInstanceId) {
+          holder.updateAppInstance(appInstanceId)
+          log("attaching lifecycle to top-level component inst=${System.identityHashCode(holder.component)}")
+          holder.attachLifecycle(lifecycleOwner)
+        }
+
+        holder.component
+      } else {
+        error("ScreenScope requires a ViewModelStoreOwner for top-level screens")
+      }
+    }
+    nested -> {
+      // Build a Subscreen from the nearest ScreenComponent.
+      val parentScreen: ScreenComponent = when (parentAny) {
+        is ScreenComponent -> parentAny
+        is SubscreenComponent -> error("Cannot nest inside another SubscreenComponent")
+        else -> error("Unsupported parent type")
+      }
+      val subBuilder = EntryPoints.get(parentScreen, SubscreenBuilderEntryPoint::class.java).subBuilder()
+      subBuilder.build().also {
+        log("created nested SubscreenComponent inst=${System.identityHashCode(it)}")
+      }
+    }
+    else -> {
+      // Reuse nearest component if not nesting.
+      parentAny
     }
   }
 
@@ -57,3 +89,5 @@ fun ScreenScope(
 
 // Expose LocalScreenComponent for the ViewModel factory
 val LocalScreenComponentProvider = LocalScreenComponent
+
+private fun log(msg: String) = Log.d("ScreenScope", msg)

--- a/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenViewModel.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/scope/ScreenViewModel.kt
@@ -1,0 +1,28 @@
+package com.archstarter.core.common.scope
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+
+/**
+ * Base class for screen-scoped ViewModels that want a lifecycle-aware [viewModelScope].
+ *
+ * When resolved through [com.archstarter.core.common.viewmodel.ScreenVmFactory] the factory sets
+ * [screenScopeHolder] right after construction. From then on, an unqualified `viewModelScope`
+ * inside subclasses resolves to the member extension below, which returns the holder's
+ * lifecycle-aware scope instead of the default [ViewModel.viewModelScope]. That scope is cancelled
+ * when the screen goes off-screen, so jobs launched from it (e.g. in `initOnce`) stop rather than
+ * leaking as stale subscriptions.
+ *
+ * Caveat: the base-class constructor runs before subclass property initializers, and the factory
+ * sets [screenScopeHolder] only after construction completes. So any `stateIn(viewModelScope)` in a
+ * property initializer captures the default scope; move such work into `initOnce` to get the
+ * lifecycle-aware behaviour.
+ */
+abstract class ScreenViewModel : ViewModel() {
+  lateinit var screenScopeHolder: ScreenScopeHolder
+
+  val ScreenViewModel.viewModelScope
+    get() =
+      if (::screenScopeHolder.isInitialized) screenScopeHolder.screenScope()
+      else (ViewModel::viewModelScope).get(this)
+}

--- a/core/common/src/main/kotlin/com/archstarter/core/common/viewmodel/MagicViewModel.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/viewmodel/MagicViewModel.kt
@@ -7,6 +7,7 @@ import androidx.savedstate.SavedStateRegistryOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
+import com.archstarter.core.common.scope.LocalAppInstanceId
 import com.archstarter.core.common.scope.LocalScreenComponentProvider
 
 @Composable
@@ -20,9 +21,15 @@ inline fun <reified VM : ViewModel> scopedViewModel(key: String?): VM {
   val component = LocalScreenComponentProvider.current
     ?: error("magicViewModel() must be called within a ScreenScope")
   val defaultArgs = (owner as? NavBackStackEntry)?.arguments
+  val appInstanceId = LocalAppInstanceId.current
 
   val factory = remember(component, owner, defaultArgs) {
     ScreenVmFactory(savedOwner, defaultArgs, component)
   }
-  return viewModel(viewModelStoreOwner = owner, factory = factory, key = key)
+  // Key must be unique per (caller key, VM type, component instance, app instance) so a fresh
+  // screen/component gets its own ViewModel instead of reusing a stale one from the store. Without
+  // the component identity + app instance in the key, re-entering a screen (or recreating the
+  // activity) can hand back a VM bound to a disposed graph — the "stale subscription" bug.
+  val fullKey = key + VM::class.java.name + System.identityHashCode(component) + appInstanceId
+  return viewModel(viewModelStoreOwner = owner, factory = factory, key = fullKey)
 }

--- a/core/common/src/main/kotlin/com/archstarter/core/common/viewmodel/ScreenVmFactory.kt
+++ b/core/common/src/main/kotlin/com/archstarter/core/common/viewmodel/ScreenVmFactory.kt
@@ -6,6 +6,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.lifecycle.ViewModel
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenScopeHolder
+import com.archstarter.core.common.scope.ScreenScopeHolderEntryPoint
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.scope.SubscreenComponent
 import com.archstarter.core.common.scope.VmMapEntryPoint
 import com.archstarter.core.common.scope.SubVmMapEntryPoint
@@ -26,9 +29,26 @@ class ScreenVmFactory(
     }
   }
 
+  // Lifecycle-aware scope holder, only available on the top-level ScreenComponent.
+  private val scopeHolder: ScreenScopeHolder? by lazy {
+    when (component) {
+      is ScreenComponent ->
+        EntryPoints.get(component, ScreenScopeHolderEntryPoint::class.java).screenScopeHolder()
+      else -> null
+    }
+  }
+
   @Suppress("UNCHECKED_CAST")
   override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
     val raw = map[modelClass] ?: error("No AssistedVmFactory bound for ${modelClass.name}")
-    return (raw as AssistedVmFactory<T>).create(handle)
+    val vm = (raw as AssistedVmFactory<T>).create(handle)
+
+    vm as? ScreenViewModel
+      ?: error("VM ${modelClass.name} must extend ScreenViewModel to receive lifecycle-aware scope")
+
+    // Attach the lifecycle-aware scope so unqualified viewModelScope in the VM is pausable.
+    scopeHolder?.let { vm.screenScopeHolder = it }
+
+    return vm
   }
 }

--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogImpl.kt
@@ -3,11 +3,11 @@ package com.archstarter.feature.catalog.impl
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.app.App
 import com.archstarter.core.common.presenter.PresenterProvider
 import com.archstarter.core.common.scope.ScreenBus
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.core.common.viewmodel.scopedViewModel
@@ -40,7 +40,7 @@ class CatalogViewModel @AssistedInject constructor(
     private val bridge: CatalogBridge,
     private val screenBus: ScreenBus, // from Screen/Subscreen (inherited)
     @Assisted private val handle: SavedStateHandle
-) : ViewModel(), CatalogPresenter {
+) : ScreenViewModel(), CatalogPresenter {
     private val _state = MutableStateFlow(CatalogState())
     override val state: StateFlow<CatalogState> = _state
 

--- a/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogItemViewModel.kt
+++ b/feature/catalog/impl/src/main/java/com/archstarter/feature/catalog/impl/CatalogItemViewModel.kt
@@ -3,10 +3,10 @@ package com.archstarter.feature.catalog.impl
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.presenter.PresenterProvider
 import com.archstarter.core.common.scope.ScreenBus
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.core.common.viewmodel.scopedViewModel
@@ -46,7 +46,7 @@ class CatalogItemViewModel @AssistedInject constructor(
     private val screenBus: ScreenBus, // from Screen/Subscreen (inherited)
     private val settingsStateProvider: SettingsStateProvider,
     @Assisted private val handle: SavedStateHandle
-) : ViewModel(), CatalogItemPresenter {
+) : ScreenViewModel(), CatalogItemPresenter {
     private val params = MutableSharedFlow<Int>(replay = 1)
     private val articles = params.flatMapLatest { id -> repo.articleFlow(id) }
     private val languagePairs = settingsStateProvider.state

--- a/feature/detail/impl/src/main/java/com/archstarter/feature/detail/impl/DetailImpl.kt
+++ b/feature/detail/impl/src/main/java/com/archstarter/feature/detail/impl/DetailImpl.kt
@@ -3,11 +3,11 @@ package com.archstarter.feature.detail.impl
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.app.App
 import com.archstarter.core.common.presenter.PresenterProvider
 import com.archstarter.core.common.scope.ScreenBus
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.core.common.viewmodel.scopedViewModel
@@ -45,7 +45,7 @@ class DetailViewModel @AssistedInject constructor(
     private val screenBus: ScreenBus, // from Screen/Subscreen (inherited)
     private val settingsStateProvider: SettingsStateProvider,
     @Assisted private val handle: SavedStateHandle
-) : ViewModel(), DetailPresenter {
+) : ScreenViewModel(), DetailPresenter {
 
     init {
         println("DetailsViewModel created vm=${System.identityHashCode(this)}, bus=${System.identityHashCode(screenBus)}")

--- a/feature/onboarding/impl/src/main/java/com/archstarter/feature/onboarding/impl/OnboardingImpl.kt
+++ b/feature/onboarding/impl/src/main/java/com/archstarter/feature/onboarding/impl/OnboardingImpl.kt
@@ -3,9 +3,9 @@ package com.archstarter.feature.onboarding.impl
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.presenter.PresenterProvider
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.core.common.viewmodel.scopedViewModel
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
 class OnboardingViewModel @AssistedInject constructor(
     private val repository: OnboardingRepository,
     @Assisted private val handle: SavedStateHandle,
-) : ViewModel(), OnboardingPresenter {
+) : ScreenViewModel(), OnboardingPresenter {
     private val _state = MutableStateFlow(OnboardingState())
     override val state: StateFlow<OnboardingState> = _state.asStateFlow()
 

--- a/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/SettingsImpl.kt
+++ b/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/SettingsImpl.kt
@@ -2,9 +2,9 @@ package com.archstarter.feature.settings.impl
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.scope.ScreenBus
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.feature.settings.api.LanguageChooserRole
@@ -29,7 +29,7 @@ class SettingsViewModel @AssistedInject constructor(
     private val screenBus: ScreenBus, // from Screen/Subscreen (inherited)
     private val languageSelectionBus: LanguageSelectionBus,
     @Assisted private val handle: SavedStateHandle
-) : ViewModel(), SettingsPresenter {
+) : ScreenViewModel(), SettingsPresenter {
     override val state: StateFlow<SettingsState> = repo.state
 
     init {

--- a/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/language/LanguageChooserViewModel.kt
+++ b/feature/settings/impl/src/main/java/com/archstarter/feature/settings/impl/language/LanguageChooserViewModel.kt
@@ -2,8 +2,8 @@ package com.archstarter.feature.settings.impl.language
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.archstarter.core.common.scope.ScreenComponent
+import com.archstarter.core.common.scope.ScreenViewModel
 import com.archstarter.core.common.viewmodel.AssistedVmFactory
 import com.archstarter.core.common.viewmodel.VmKey
 import com.archstarter.feature.settings.api.LanguageChooserParams
@@ -30,7 +30,7 @@ class LanguageChooserViewModel @AssistedInject constructor(
     private val repository: LanguageRepository,
     private val selectionBus: LanguageSelectionBus,
     @Suppress("unused") @Assisted private val savedStateHandle: SavedStateHandle,
-) : ViewModel(), LanguageChooserPresenter {
+) : ScreenViewModel(), LanguageChooserPresenter {
 
     private val _state = MutableStateFlow(LanguageChooserState())
     override val state: StateFlow<LanguageChooserState> = _state.asStateFlow()


### PR DESCRIPTION
Ports the screen-scope architecture fixes from the production irobot-home app into the starter, solving several critical lifecycle bugs.

## Bugs fixed
| Symptom | Root cause |
|---|---|
| Screen **flickering** after an async task | Jobs launched in `initOnce` via `viewModelScope.launch` were never cancelled off-screen |
| Tap on a button **does nothing** | `scopedViewModel` reused a **stale VM** because the key omitted component identity |
| App **unresponsive** after font-scale change | Activity recreation didn't rebuild the Hilt screen graph → stale singletons |
| Off-screen subscription leaks / re-login | `rememberPresenter` used `LaunchedEffect`, so `initOnce` ran once with no stop signal |

## Changes
- **`ScreenScopeHolder`** (new) — lifecycle-aware coroutine scope: cancels children on `ON_STOP`, recreates on `ON_START`, hard-cancels on component disposal.
- **`ScreenViewModel`** (new) — base VM whose unqualified `viewModelScope` becomes the lifecycle-aware scope; all 6 feature VMs extend it.
- **`ScreenComponentHolder`** (new) — holds the `ScreenComponent` in a `ViewModel` matching the `NavBackStackEntry` lifetime; rebuilds the graph when the App instance changes.
- `scopedViewModel` key now includes VM type + component identity + `appInstanceId`.
- `rememberPresenter` uses `LifecycleStartEffect` + new `LifecycleStop` interface.
- `Nav.kt` provides `LocalAppInstanceId`.

## Verification
All modules compile, 24 unit tests pass, `:app:assembleDebug` succeeds (Hilt graph valid) under JDK 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)