### PR TITLE
Disable CI execution for fork pull requests

### DIFF
--- a/.github/workflows/build-on-comment.yml
+++ b/.github/workflows/build-on-comment.yml
@@ -59,6 +59,12 @@ jobs:
             core.setOutput('head_repo', pr.data.head.repo.full_name);
             core.setOutput('head_sha', pr.data.head.sha);
 
+      - name: Reject fork pull requests
+        if: steps.trigger.outputs.should_run == 'true' && steps.prinfo.outputs.head_repo != github.repository
+        run: |
+          echo "Fork pull-request builds are disabled." >&2
+          exit 1
+
       - name: Checkout PR merge ref
         id: checkout-merge
         if: steps.trigger.outputs.should_run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- prevent fork-originated pull requests from executing CI jobs
- preserve normal checks for same-repository pull requests and trusted push/tag/manual events
- pair workflow guards with the repository policy requiring approval for all external contributors

## Validation

- all workflow YAML files parsed successfully
- git diff --check passed